### PR TITLE
Add the created network URI as an output

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,11 @@ The subnets list contains maps, where each object represents a subnet. Each map 
 | Name | Description |
 |------|-------------|
 | network_name | The name of the VPC being created |
+| network_self_link | The URI of the VPC being created |
 | subnets_ips | The IPs and CIDRs of the subnets being created |
 | subnets_names | The names of the subnets being created |
 | subnets_private_access | Whether the subnets will have access to Google API's without a public IP |
-| subnet_flow_logs | Whether the subnets will have VPC flow logs enabled |
+| subnets_flow_logs | Whether the subnets will have VPC flow logs enabled |
 | subnets_regions | The region where the subnets will be created |
 | subnets_secondary_ranges | The secondary ranges associated with these subnets |
 

--- a/examples/multi_vpc/README.md
+++ b/examples/multi_vpc/README.md
@@ -16,7 +16,6 @@ This example configures a host network project with two separate networks.
 | Name | Description |
 |------|-------------|
 | network_01_name | vpc 1 |
-| network_01_self_link | The URI of the VPC network-02 |
 | network_01_self_link | The URI of the VPC network-01 |
 | network_01_subnets | The names of the subnets being created on network-01 |
 | network_01_subnets_flow_logs | Whether the subnets will have VPC flow logs enabled |
@@ -25,6 +24,7 @@ This example configures a host network project with two separate networks.
 | network_01_subnets_regions | The region where the subnets will be created on network-01 |
 | network_01_subnets_secondary_ranges | The secondary ranges associated with these subnets on network-01 |
 | network_02_name | vpc 2 |
+| network_02_self_link | The URI of the VPC network-02 |
 | network_02_subnets | The names of the subnets being created on network-02 |
 | network_02_subnets_flow_logs | Whether the subnets will have VPC flow logs enabled |
 | network_02_subnets_ips | The IP and cidrs of the subnets being created on network-02 |

--- a/examples/multi_vpc/README.md
+++ b/examples/multi_vpc/README.md
@@ -16,13 +16,17 @@ This example configures a host network project with two separate networks.
 | Name | Description |
 |------|-------------|
 | network_01_name | vpc 1 |
+| network_01_self_link | The URI of the VPC network-02 |
+| network_01_self_link | The URI of the VPC network-01 |
 | network_01_subnets | The names of the subnets being created on network-01 |
+| network_01_subnets_flow_logs | Whether the subnets will have VPC flow logs enabled |
 | network_01_subnets_ips | The IP and cidrs of the subnets being created on network-01 |
 | network_01_subnets_private_access | Whether the subnets will have access to Google API's without a public IP on network-01 |
 | network_01_subnets_regions | The region where the subnets will be created on network-01 |
 | network_01_subnets_secondary_ranges | The secondary ranges associated with these subnets on network-01 |
 | network_02_name | vpc 2 |
 | network_02_subnets | The names of the subnets being created on network-02 |
+| network_02_subnets_flow_logs | Whether the subnets will have VPC flow logs enabled |
 | network_02_subnets_ips | The IP and cidrs of the subnets being created on network-02 |
 | network_02_subnets_private_access | Whether the subnets will have access to Google API's without a public IP on network-02 |
 | network_02_subnets_regions | The region where the subnets will be created on network-02 |

--- a/examples/multi_vpc/outputs.tf
+++ b/examples/multi_vpc/outputs.tf
@@ -61,7 +61,7 @@ output "network_02_name" {
   description = "The name of the VPC network-02"
 }
 
-output "network_01_self_link" {
+output "network_02_self_link" {
   value       = "${module.test-vpc-module-02.network_self_link}"
   description = "The URI of the VPC network-02"
 }

--- a/examples/multi_vpc/outputs.tf
+++ b/examples/multi_vpc/outputs.tf
@@ -20,6 +20,11 @@ output "network_01_name" {
   description = "The name of the VPC network-01"
 }
 
+output "network_01_self_link" {
+  value       = "${module.test-vpc-module-01.network_self_link}"
+  description = "The URI of the VPC network-01"
+}
+
 output "network_01_subnets" {
   value       = "${module.test-vpc-module-01.subnets_names}"
   description = "The names of the subnets being created on network-01"
@@ -54,6 +59,11 @@ output "network_01_subnets_secondary_ranges" {
 output "network_02_name" {
   value       = "${module.test-vpc-module-02.network_name}"
   description = "The name of the VPC network-02"
+}
+
+output "network_01_self_link" {
+  value       = "${module.test-vpc-module-02.network_self_link}"
+  description = "The URI of the VPC network-02"
 }
 
 output "network_02_subnets" {

--- a/examples/simple_project/README.md
+++ b/examples/simple_project/README.md
@@ -17,7 +17,9 @@ This VPC has two subnets, with the first subnet being given a single secondary r
 
 | Name | Description |
 |------|-------------|
+| network_01_self_link | The URI of the VPC being created |
 | network_name | The name of the VPC being created |
+| subnets_flow_logs | Whether the subnets will have VPC flow logs enabled |
 | subnets_ips | The IP and cidrs of the subnets being created |
 | subnets_names | The names of the subnets being created |
 | subnets_private_access | Whether the subnets will have access to Google API's without a public IP |

--- a/examples/simple_project/README.md
+++ b/examples/simple_project/README.md
@@ -17,8 +17,8 @@ This VPC has two subnets, with the first subnet being given a single secondary r
 
 | Name | Description |
 |------|-------------|
-| network_01_self_link | The URI of the VPC being created |
 | network_name | The name of the VPC being created |
+| network_self_link | The URI of the VPC being created |
 | subnets_flow_logs | Whether the subnets will have VPC flow logs enabled |
 | subnets_ips | The IP and cidrs of the subnets being created |
 | subnets_names | The names of the subnets being created |

--- a/examples/simple_project/outputs.tf
+++ b/examples/simple_project/outputs.tf
@@ -19,6 +19,11 @@ output "network_name" {
   description = "The name of the VPC being created"
 }
 
+output "network_01_self_link" {
+  value       = "${module.test-vpc-module.network_self_link}"
+  description = "The URI of the VPC being created"
+}
+
 output "subnets_names" {
   value       = "${module.test-vpc-module.subnets_names}"
   description = "The names of the subnets being created"

--- a/examples/simple_project/outputs.tf
+++ b/examples/simple_project/outputs.tf
@@ -19,7 +19,7 @@ output "network_name" {
   description = "The name of the VPC being created"
 }
 
-output "network_01_self_link" {
+output "network_self_link" {
   value       = "${module.test-vpc-module.network_self_link}"
   description = "The URI of the VPC being created"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,6 +19,11 @@ output "network_name" {
   description = "The name of the VPC being created"
 }
 
+output "network_self_link" {
+  value       = "${google_compute_network.network.self_link}"
+  description = "The URI of the VPC being created"
+}
+
 output "subnets_names" {
   value       = "${google_compute_subnetwork.subnetwork.*.name}"
   description = "The names of the subnets being created"

--- a/test/integration/gcloud-test/templates/outputs.tf.tmpl
+++ b/test/integration/gcloud-test/templates/outputs.tf.tmpl
@@ -19,6 +19,11 @@ output "network_name" {
   description = "The name of the VPC network-01"
 }
 
+output "network_self_link" {
+  value       = "\${module.test-vpc-module-01.network_self_link}"
+  description = "The URI of the VPC network-01"
+}
+
 output "subnets_names" {
   value       = "\${module.test-vpc-module-01.subnets_names}"
   description = "The names of the subnets being created on network-01"


### PR DESCRIPTION
This change adds the `self_link` of the created network as an output. Also updated the examples and generated the READMEs with terraform-docs.