### PR TITLE
Updated terraform-provider-google min version to 1.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The subnets list contains maps, where each object represents a subnet. Each map 
 ## Requirements
 ### Terraform plugins
 - [Terraform](https://www.terraform.io/downloads.html) 0.10.x
-- [terraform-provider-google](https://github.com/terraform-providers/terraform-provider-google) plugin v1.8.0
+- [terraform-provider-google](https://github.com/terraform-providers/terraform-provider-google) plugin v1.12.0
 
 ### Configure a Service Account
 In order to execute this module you must have a Service Account with the following roles:


### PR DESCRIPTION
Overview:
- The enable_flow_logs field to subnetwork resource was introduced in terraform-provider-google version 1.12.0. Used at https://github.com/rbramwell/terraform-google-network/blob/master/main.tf#L37
- See https://github.com/terraform-providers/terraform-provider-google/blob/master/CHANGELOG.md#1120-may-04-2018