### PR TITLE
[docs] Change source reference in README to reflect registry source address

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can go to the examples folder, however the usage of the module could be like
 
 ```hcl
 module "vpc" {
-    source = "github.com/terraform-google-modules/terraform-google-network"
+    source = "terraform-google-modules/network/google"
     project_id   = "<PROJECT ID>"
     network_name = "example-vpc"
 


### PR DESCRIPTION

This PR changes the github source referenced in the README example docs to a standard registry source address to reference the published registry module.
