### PR TITLE
Adds subnet data source, allows no secondary range in subnets; fixes #5

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,14 @@ resource "google_compute_subnetwork" "subnetwork" {
   secondary_ip_range = "${var.secondary_ranges[lookup(var.subnets[count.index], "subnet_name")]}"
 }
 
+data "google_compute_subnetwork" "created_subnets" {
+  count = "${length(var.subnets)}"
+
+  name    = "${lookup(var.subnets[count.index], "subnet_name")}"
+  region  = "${lookup(var.subnets[count.index], "subnet_region")}"
+  project = "${var.project_id}"
+}
+
 /******************************************
 	Routes
  *****************************************/

--- a/outputs.tf
+++ b/outputs.tf
@@ -50,7 +50,7 @@ output "subnets_flow_logs" {
 }
 
 output "subnets_secondary_ranges" {
-  value       = "${google_compute_subnetwork.subnetwork.*.secondary_ip_range}"
+  value       = "${data.google_compute_subnetwork.created_subnets.*.secondary_ip_range}"
   description = "The secondary ranges associated with these subnets"
 }
 


### PR DESCRIPTION
This will fix #5, which causes errors when the `secondary_ranges` map does not define any secondary ranges.  This keeps the `subnets_secondary_ranges` output, but we might consider removing it altogether, since it is capable of producing such useless output as:

```
Outputs:

secondary_ranges = [
    [
    ],
    [
    ],
    [
    ]
]
```

Removing the output is something I'm happy to do, if that's the direction we choose to go.