### PR TITLE
Refactor integration tests to include random names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,50 +84,60 @@ docker_run:
 	docker run --rm -it \
 		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
 		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
-		-e TF_VAR_project_id \
+		-e PROJECT_ID \
+		-e SERVICE_ACCOUNT_JSON \
+		-e RANDOM_STRING_FOR_TESTING \
 		-v $(CURDIR):/cft/workdir \
 		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
-		/bin/bash
+		/bin/bash -c 'source test/ci_integration.sh && setup_environment && exec /bin/bash'
 
 .PHONY: docker_create
 docker_create:
 	docker run --rm -it \
 		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
 		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
-		-e TF_VAR_project_id \
+		-e PROJECT_ID \
+		-e SERVICE_ACCOUNT_JSON \
+		-e RANDOM_STRING_FOR_TESTING \
 		-v $(CURDIR):/cft/workdir \
 		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
-		/bin/bash -c "kitchen create"
+		/bin/bash -c "source test/ci_integration.sh && setup_environment && kitchen create"
 
 .PHONY: docker_converge
 docker_converge:
 	docker run --rm -it \
 		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
 		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
-		-e TF_VAR_project_id \
+		-e PROJECT_ID \
+		-e SERVICE_ACCOUNT_JSON \
+		-e RANDOM_STRING_FOR_TESTING \
 		-v $(CURDIR):/cft/workdir \
 		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
-		/bin/bash -c "kitchen converge && kitchen converge"
+		/bin/bash -c "source test/ci_integration.sh && setup_environment && kitchen converge && kitchen converge"
 
 .PHONY: docker_verify
 docker_verify:
 	docker run --rm -it \
 		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
 		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
-		-e TF_VAR_project_id \
+		-e PROJECT_ID \
+		-e SERVICE_ACCOUNT_JSON \
+		-e RANDOM_STRING_FOR_TESTING \
 		-v $(CURDIR):/cft/workdir \
 		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
-		/bin/bash -c "kitchen verify"
+		/bin/bash -c "source test/ci_integration.sh && setup_environment && kitchen verify"
 
 .PHONY: docker_destroy
 docker_destroy:
 	docker run --rm -it \
 		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
 		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
-		-e TF_VAR_project_id \
+		-e PROJECT_ID \
+		-e SERVICE_ACCOUNT_JSON \
+		-e RANDOM_STRING_FOR_TESTING \
 		-v $(CURDIR):/cft/workdir \
 		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
-		/bin/bash -c "kitchen destroy"
+		/bin/bash -c "source test/ci_integration.sh && setup_environment && kitchen destroy"
 
 .PHONY: test_integration_docker
 test_integration_docker: docker_create docker_converge docker_verify docker_destroy

--- a/README.md
+++ b/README.md
@@ -75,34 +75,33 @@ Then perform the following commands on the root folder:
 
 [^]: (autogen_docs_start)
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| delete_default_internet_gateway_routes | If set, ensure that all routes within the network specified whose names begin with 'default-route' and with a next hop of 'default-internet-gateway' are deleted | string | `false` | no |
-| network_name | The name of the network being created | string | - | yes |
-| project_id | The ID of the project where this VPC will be created | string | - | yes |
+| delete\_default\_internet\_gateway\_routes | If set, ensure that all routes within the network specified whose names begin with 'default-route' and with a next hop of 'default-internet-gateway' are deleted | string | `"false"` | no |
+| network\_name | The name of the network being created | string | n/a | yes |
+| project\_id | The ID of the project where this VPC will be created | string | n/a | yes |
 | routes | List of routes being created in this VPC | list | `<list>` | no |
-| routing_mode | The network routing mode (default 'GLOBAL') | string | `GLOBAL` | no |
-| secondary_ranges | Secondary ranges that will be used in some of the subnets | map | - | yes |
-| shared_vpc_host | Makes this project a Shared VPC host if 'true' (default 'false') | string | `false` | no |
-| subnets | The list of subnets being created | list | - | yes |
+| routing\_mode | The network routing mode (default 'GLOBAL') | string | `"GLOBAL"` | no |
+| secondary\_ranges | Secondary ranges that will be used in some of the subnets | map | n/a | yes |
+| shared\_vpc\_host | Makes this project a Shared VPC host if 'true' (default 'false') | string | `"false"` | no |
+| subnets | The list of subnets being created | list | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| network_name | The name of the VPC being created |
-| network_self_link | The URI of the VPC being created |
+| network\_name | The name of the VPC being created |
+| network\_self\_link | The URI of the VPC being created |
 | routes | The routes associated with this VPC |
-| subnets_flow_logs | Whether the subnets will have VPC flow logs enabled |
-| subnets_ips | The IPs and CIDRs of the subnets being created |
-| subnets_names | The names of the subnets being created |
-| subnets_private_access | Whether the subnets will have access to Google API's without a public IP |
-| subnets_regions | The region where the subnets will be created |
-| subnets_secondary_ranges | The secondary ranges associated with these subnets |
-| subnets_self_links | The self-links of subnets being created |
+| subnets\_flow\_logs | Whether the subnets will have VPC flow logs enabled |
+| subnets\_ips | The IPs and CIDRs of the subnets being created |
+| subnets\_names | The names of the subnets being created |
+| subnets\_private\_access | Whether the subnets will have access to Google API's without a public IP |
+| subnets\_regions | The region where the subnets will be created |
+| subnets\_secondary\_ranges | The secondary ranges associated with these subnets |
+| subnets\_self\_links | The self-links of subnets being created |
 
 [^]: (autogen_docs_end)
 

--- a/examples/delete_default_gateway_routes/README.md
+++ b/examples/delete_default_gateway_routes/README.md
@@ -6,25 +6,25 @@ This VPC has a single subnet with no secondary ranges, and ensures the default i
 
 [^]: (autogen_docs_start)
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| project_id | The project ID to host the network in | string | - | yes |
+| network\_name | The name of the VPC network being created | string | n/a | yes |
+| project\_id | The project ID to host the network in | string | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| network_name | The name of the VPC being created |
-| network_self_link | The URI of the VPC being created |
+| network\_name | The name of the VPC being created |
+| network\_self\_link | The URI of the VPC being created |
 | routes | The routes associated with this VPC |
-| subnets_flow_logs | Whether the subnets will have VPC flow logs enabled |
-| subnets_ips | The IP and cidrs of the subnets being created |
-| subnets_names | The names of the subnets being created |
-| subnets_private_access | Whether the subnets will have access to Google API's without a public IP |
-| subnets_regions | The region where subnets will be created |
-| subnets_secondary_ranges | The secondary ranges associated with these subnets |
+| subnets\_flow\_logs | Whether the subnets will have VPC flow logs enabled |
+| subnets\_ips | The IP and cidrs of the subnets being created |
+| subnets\_names | The names of the subnets being created |
+| subnets\_private\_access | Whether the subnets will have access to Google API's without a public IP |
+| subnets\_regions | The region where subnets will be created |
+| subnets\_secondary\_ranges | The secondary ranges associated with these subnets |
 
 [^]: (autogen_docs_end)

--- a/examples/delete_default_gateway_routes/main.tf
+++ b/examples/delete_default_gateway_routes/main.tf
@@ -15,30 +15,24 @@
  */
 
 locals {
-  network_name = "test-network-${random_string.random_suffix.result}"
-}
-
-resource "random_string" "random_suffix" {
-  length  = 4
-  upper   = "false"
-  special = "false"
+  subnet_01 = "${var.network_name}-subnet-01"
 }
 
 module "test-vpc-module" {
   source                                 = "../../"
   project_id                             = "${var.project_id}"
-  network_name                           = "${local.network_name}"
+  network_name                           = "${var.network_name}"
   delete_default_internet_gateway_routes = "true"
 
   subnets = [
     {
-      subnet_name   = "subnet-41"
+      subnet_name   = "${local.subnet_01}"
       subnet_ip     = "10.20.30.0/24"
       subnet_region = "us-west1"
     },
   ]
 
   secondary_ranges = {
-    subnet-41 = []
+    "${local.subnet_01}" = []
   }
 }

--- a/examples/delete_default_gateway_routes/variables.tf
+++ b/examples/delete_default_gateway_routes/variables.tf
@@ -17,3 +17,7 @@
 variable "project_id" {
   description = "The project ID to host the network in"
 }
+
+variable "network_name" {
+  description = "The name of the VPC network being created"
+}

--- a/examples/multi_vpc/README.md
+++ b/examples/multi_vpc/README.md
@@ -4,34 +4,35 @@ This example configures a host network project with two separate networks.
 
 [^]: (autogen_docs_start)
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| project_id | The project ID to host the network in | string | - | yes |
+| network\_01\_name | The name of the first VPC network being created | string | n/a | yes |
+| network\_02\_name | The name of the second VPC network being created | string | n/a | yes |
+| project\_id | The project ID to host the network in | string | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| network_01_name | The name of the VPC network-01 |
-| network_01_routes | The routes associated with network-01 |
-| network_01_self_link | The URI of the VPC network-01 |
-| network_01_subnets | The names of the subnets being created on network-01 |
-| network_01_subnets_flow_logs | Whether the subnets will have VPC flow logs enabled |
-| network_01_subnets_ips | The IP and cidrs of the subnets being created on network-01 |
-| network_01_subnets_private_access | Whether the subnets will have access to Google API's without a public IP on network-01 |
-| network_01_subnets_regions | The region where the subnets will be created on network-01 |
-| network_01_subnets_secondary_ranges | The secondary ranges associated with these subnets on network-01 |
-| network_02_name | The name of the VPC network-02 |
-| network_02_routes | The routes associated with network-02 |
-| network_02_self_link | The URI of the VPC network-02 |
-| network_02_subnets | The names of the subnets being created on network-02 |
-| network_02_subnets_flow_logs | Whether the subnets will have VPC flow logs enabled |
-| network_02_subnets_ips | The IP and cidrs of the subnets being created on network-02 |
-| network_02_subnets_private_access | Whether the subnets will have access to Google API's without a public IP on network-02 |
-| network_02_subnets_regions | The region where the subnets will be created on network-02 |
-| network_02_subnets_secondary_ranges | The secondary ranges associated with these subnets on network-02 |
+| network\_01\_name | The name of the VPC network-01 |
+| network\_01\_routes | The routes associated with network-01 |
+| network\_01\_self\_link | The URI of the VPC network-01 |
+| network\_01\_subnets | The names of the subnets being created on network-01 |
+| network\_01\_subnets\_flow\_logs | Whether the subnets will have VPC flow logs enabled |
+| network\_01\_subnets\_ips | The IP and cidrs of the subnets being created on network-01 |
+| network\_01\_subnets\_private\_access | Whether the subnets will have access to Google API's without a public IP on network-01 |
+| network\_01\_subnets\_regions | The region where the subnets will be created on network-01 |
+| network\_01\_subnets\_secondary\_ranges | The secondary ranges associated with these subnets on network-01 |
+| network\_02\_name | The name of the VPC network-02 |
+| network\_02\_routes | The routes associated with network-02 |
+| network\_02\_self\_link | The URI of the VPC network-02 |
+| network\_02\_subnets | The names of the subnets being created on network-02 |
+| network\_02\_subnets\_flow\_logs | Whether the subnets will have VPC flow logs enabled |
+| network\_02\_subnets\_ips | The IP and cidrs of the subnets being created on network-02 |
+| network\_02\_subnets\_private\_access | Whether the subnets will have access to Google API's without a public IP on network-02 |
+| network\_02\_subnets\_regions | The region where the subnets will be created on network-02 |
+| network\_02\_subnets\_secondary\_ranges | The secondary ranges associated with these subnets on network-02 |
 
 [^]: (autogen_docs_end)

--- a/examples/multi_vpc/main.tf
+++ b/examples/multi_vpc/main.tf
@@ -15,12 +15,15 @@
  */
 
 locals {
-  network_01_name = "test-network-301"
-  network_02_name = "test-network-302"
+  network_01_subnet_01 = "${var.network_01_name}-subnet-01"
+  network_01_subnet_02 = "${var.network_01_name}-subnet-02"
+  network_01_subnet_03 = "${var.network_01_name}-subnet-03"
+  network_02_subnet_01 = "${var.network_02_name}-subnet-01"
+  network_02_subnet_02 = "${var.network_02_name}-subnet-02"
 
   network_01_routes = [
     {
-      name              = "${local.network_01_name}-egress-inet"
+      name              = "${var.network_01_name}-egress-inet"
       description       = "route through IGW to access internet"
       destination_range = "0.0.0.0/0"
       tags              = "egress-inet"
@@ -30,14 +33,14 @@ locals {
 
   network_02_routes = [
     {
-      name              = "${local.network_02_name}-egress-inet"
+      name              = "${var.network_02_name}-egress-inet"
       description       = "route through IGW to access internet"
       destination_range = "0.0.0.0/0"
       tags              = "egress-inet"
       next_hop_internet = "true"
     },
     {
-      name              = "${local.network_02_name}-testapp-proxy"
+      name              = "${var.network_02_name}-testapp-proxy"
       description       = "route through proxy to reach app"
       destination_range = "10.50.10.0/24"
       tags              = "app-proxy"
@@ -46,40 +49,28 @@ locals {
   ]
 }
 
-resource "random_string" "random_suffix_01" {
-  length  = 4
-  upper   = "false"
-  special = "false"
-}
-
-resource "random_string" "random_suffix_02" {
-  length  = 4
-  upper   = "false"
-  special = "false"
-}
-
 module "test-vpc-module-01" {
   source       = "../../"
   project_id   = "${var.project_id}"
-  network_name = "test-network-${random_string.random_suffix_01.result}"
+  network_name = "${var.network_01_name}"
 
   subnets = [
     {
-      subnet_name           = "${local.network_01_name}-subnet-01"
+      subnet_name           = "${local.network_01_subnet_01}"
       subnet_ip             = "10.10.10.0/24"
       subnet_region         = "us-west1"
       subnet_private_access = "false"
       subnet_flow_logs      = "true"
     },
     {
-      subnet_name           = "${local.network_01_name}-subnet-02"
+      subnet_name           = "${local.network_01_subnet_02}"
       subnet_ip             = "10.10.20.0/24"
       subnet_region         = "us-west1"
       subnet_private_access = "false"
       subnet_flow_logs      = "true"
     },
     {
-      subnet_name           = "${local.network_01_name}-subnet-03"
+      subnet_name           = "${local.network_01_subnet_03}"
       subnet_ip             = "10.10.30.0/24"
       subnet_region         = "us-west1"
       subnet_private_access = "false"
@@ -88,25 +79,25 @@ module "test-vpc-module-01" {
   ]
 
   secondary_ranges = {
-    "${local.network_01_name}-subnet-01" = [
+    "${local.network_01_subnet_01}" = [
       {
-        range_name    = "${local.network_01_name}-subnet-01-01"
+        range_name    = "${local.network_01_subnet_01}-01"
         ip_cidr_range = "192.168.64.0/24"
       },
       {
-        range_name    = "${local.network_01_name}-subnet-01-02"
+        range_name    = "${local.network_01_subnet_01}-02"
         ip_cidr_range = "192.168.65.0/24"
       },
     ]
 
-    "${local.network_01_name}-subnet-02" = [
+    "${local.network_01_subnet_02}" = [
       {
-        range_name    = "${local.network_01_name}-subnet-02-01"
+        range_name    = "${local.network_02_subnet_01}-01"
         ip_cidr_range = "192.168.74.0/24"
       },
     ]
 
-    "${local.network_01_name}-subnet-03" = []
+    "${local.network_01_subnet_03}" = []
   }
 
   routes = "${local.network_01_routes}"
@@ -115,18 +106,18 @@ module "test-vpc-module-01" {
 module "test-vpc-module-02" {
   source       = "../../"
   project_id   = "${var.project_id}"
-  network_name = "test-network-${random_string.random_suffix_02.result}"
+  network_name = "${var.network_02_name}"
 
   subnets = [
     {
-      subnet_name           = "${local.network_02_name}-subnet-01"
+      subnet_name           = "${local.network_02_subnet_01}"
       subnet_ip             = "10.10.40.0/24"
       subnet_region         = "us-west1"
       subnet_private_access = "false"
       subnet_flow_logs      = "true"
     },
     {
-      subnet_name           = "${local.network_02_name}-subnet-02"
+      subnet_name           = "${local.network_02_subnet_02}"
       subnet_ip             = "10.10.50.0/24"
       subnet_region         = "us-west1"
       subnet_private_access = "false"
@@ -135,14 +126,14 @@ module "test-vpc-module-02" {
   ]
 
   secondary_ranges = {
-    "${local.network_02_name}-subnet-01" = [
+    "${local.network_02_subnet_01}" = [
       {
-        range_name    = "${local.network_02_name}-subnet-02-01"
+        range_name    = "${local.network_02_subnet_02}-01"
         ip_cidr_range = "192.168.75.0/24"
       },
     ]
 
-    "${local.network_02_name}-subnet-02" = []
+    "${local.network_02_subnet_02}" = []
   }
 
   routes = "${local.network_02_routes}"

--- a/examples/multi_vpc/variables.tf
+++ b/examples/multi_vpc/variables.tf
@@ -17,3 +17,11 @@
 variable "project_id" {
   description = "The project ID to host the network in"
 }
+
+variable "network_01_name" {
+  description = "The name of the first VPC network being created"
+}
+
+variable "network_02_name" {
+  description = "The name of the second VPC network being created"
+}

--- a/examples/secondary_ranges/README.md
+++ b/examples/secondary_ranges/README.md
@@ -7,25 +7,25 @@ ranges and the third being given a single secondary range.
 
 [^]: (autogen_docs_start)
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| project_id | The project ID to host the network in | string | - | yes |
+| network\_name | The name of the VPC network being created | string | n/a | yes |
+| project\_id | The project ID to host the network in | string | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| network_name | The name of the VPC being created |
-| network_self_link | The URI of the VPC being created |
+| network\_name | The name of the VPC being created |
+| network\_self\_link | The URI of the VPC being created |
 | routes | The routes associated with this VPC |
-| subnets_flow_logs | Whether the subnets will have VPC flow logs enabled |
-| subnets_ips | The IP and cidrs of the subnets being created |
-| subnets_names | The names of the subnets being created |
-| subnets_private_access | Whether the subnets will have access to Google API's without a public IP |
-| subnets_regions | The region where subnets will be created |
-| subnets_secondary_ranges | The secondary ranges associated with these subnets |
+| subnets\_flow\_logs | Whether the subnets will have VPC flow logs enabled |
+| subnets\_ips | The IP and cidrs of the subnets being created |
+| subnets\_names | The names of the subnets being created |
+| subnets\_private\_access | Whether the subnets will have access to Google API's without a public IP |
+| subnets\_regions | The region where subnets will be created |
+| subnets\_secondary\_ranges | The secondary ranges associated with these subnets |
 
 [^]: (autogen_docs_end)

--- a/examples/secondary_ranges/main.tf
+++ b/examples/secondary_ranges/main.tf
@@ -15,57 +15,53 @@
  */
 
 locals {
-  network_name = "test-network-${random_string.random_suffix.result}"
-}
-
-resource "random_string" "random_suffix" {
-  length  = 4
-  upper   = "false"
-  special = "false"
+  subnet_01 = "${var.network_name}-subnet-01"
+  subnet_02 = "${var.network_name}-subnet-02"
+  subnet_03 = "${var.network_name}-subnet-03"
 }
 
 module "vpc-secondary-ranges" {
   source       = "../../"
   project_id   = "${var.project_id}"
-  network_name = "${local.network_name}"
+  network_name = "${var.network_name}"
 
   subnets = [
     {
-      subnet_name   = "secondary-ranges-subnet-01"
+      subnet_name   = "${local.subnet_01}"
       subnet_ip     = "10.10.10.0/24"
       subnet_region = "us-west1"
     },
     {
-      subnet_name           = "secondary-ranges-subnet-02"
+      subnet_name           = "${local.subnet_02}"
       subnet_ip             = "10.10.20.0/24"
       subnet_region         = "us-west1"
       subnet_private_access = "true"
       subnet_flow_logs      = "true"
     },
     {
-      subnet_name   = "secondary-ranges-subnet-03"
+      subnet_name   = "${local.subnet_03}"
       subnet_ip     = "10.10.30.0/24"
       subnet_region = "us-west1"
     },
   ]
 
   secondary_ranges = {
-    secondary-ranges-subnet-01 = [
+    "${local.subnet_01}" = [
       {
-        range_name    = "subnet-01-01"
+        range_name    = "${local.subnet_01}-01"
         ip_cidr_range = "192.168.64.0/24"
       },
       {
-        range_name    = "subnet-01-02"
+        range_name    = "${local.subnet_01}-02"
         ip_cidr_range = "192.168.65.0/24"
       },
     ]
 
-    secondary-ranges-subnet-02 = []
+    "${local.subnet_02}" = []
 
-    secondary-ranges-subnet-03 = [
+    "${local.subnet_03}" = [
       {
-        range_name    = "subnet-03-01"
+        range_name    = "${local.subnet_03}-01"
         ip_cidr_range = "192.168.66.0/24"
       },
     ]

--- a/examples/secondary_ranges/variables.tf
+++ b/examples/secondary_ranges/variables.tf
@@ -17,3 +17,7 @@
 variable "project_id" {
   description = "The project ID to host the network in"
 }
+
+variable "network_name" {
+  description = "The name of the VPC network being created"
+}

--- a/examples/simple_project/README.md
+++ b/examples/simple_project/README.md
@@ -6,25 +6,25 @@ This VPC has two subnets, with no secondary ranges.
 
 [^]: (autogen_docs_start)
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| project_id | The project ID to host the network in | string | - | yes |
+| network\_name | The name of the VPC network being created | string | n/a | yes |
+| project\_id | The project ID to host the network in | string | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| network_name | The name of the VPC being created |
-| network_self_link | The URI of the VPC being created |
+| network\_name | The name of the VPC being created |
+| network\_self\_link | The URI of the VPC being created |
 | routes | The routes associated with this VPC |
-| subnets_flow_logs | Whether the subnets will have VPC flow logs enabled |
-| subnets_ips | The IP and cidrs of the subnets being created |
-| subnets_names | The names of the subnets being created |
-| subnets_private_access | Whether the subnets will have access to Google API's without a public IP |
-| subnets_regions | The region where subnets will be created |
-| subnets_secondary_ranges | The secondary ranges associated with these subnets |
+| subnets\_flow\_logs | Whether the subnets will have VPC flow logs enabled |
+| subnets\_ips | The IP and cidrs of the subnets being created |
+| subnets\_names | The names of the subnets being created |
+| subnets\_private\_access | Whether the subnets will have access to Google API's without a public IP |
+| subnets\_regions | The region where subnets will be created |
+| subnets\_secondary\_ranges | The secondary ranges associated with these subnets |
 
 [^]: (autogen_docs_end)

--- a/examples/simple_project/main.tf
+++ b/examples/simple_project/main.tf
@@ -13,30 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 locals {
-  network_name = "test-network-${random_string.random_suffix.result}"
-}
-
-resource "random_string" "random_suffix" {
-  length  = 4
-  upper   = "false"
-  special = "false"
+  subnet_01 = "${var.network_name}-subnet-01"
+  subnet_02 = "${var.network_name}-subnet-02"
 }
 
 module "test-vpc-module" {
   source       = "../../"
   project_id   = "${var.project_id}"
-  network_name = "${local.network_name}"
+  network_name = "${var.network_name}"
 
   subnets = [
     {
-      subnet_name   = "subnet-01"
+      subnet_name   = "${local.subnet_01}"
       subnet_ip     = "10.10.10.0/24"
       subnet_region = "us-west1"
     },
     {
-      subnet_name           = "subnet-02"
+      subnet_name           = "${local.subnet_02}"
       subnet_ip             = "10.10.20.0/24"
       subnet_region         = "us-west1"
       subnet_private_access = "true"
@@ -45,7 +39,7 @@ module "test-vpc-module" {
   ]
 
   secondary_ranges = {
-    subnet-01 = []
-    subnet-02 = []
+    "${local.subnet_01}" = []
+    "${local.subnet_02}" = []
   }
 }

--- a/examples/simple_project/variables.tf
+++ b/examples/simple_project/variables.tf
@@ -17,3 +17,7 @@
 variable "project_id" {
   description = "The project ID to host the network in"
 }
+
+variable "network_name" {
+  description = "The name of the VPC network being created"
+}

--- a/examples/simple_project_with_regional_network/README.md
+++ b/examples/simple_project_with_regional_network/README.md
@@ -6,25 +6,25 @@ This VPC has two subnets, with no secondary ranges.
 
 [^]: (autogen_docs_start)
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| project_id | The project ID to host the network in | string | - | yes |
+| network\_name | The name of the VPC network being created | string | n/a | yes |
+| project\_id | The project ID to host the network in | string | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| network_name | The name of the VPC being created |
-| network_self_link | The URI of the VPC being created |
+| network\_name | The name of the VPC being created |
+| network\_self\_link | The URI of the VPC being created |
 | routes | The routes associated with this VPC |
-| subnets_flow_logs | Whether the subnets will have VPC flow logs enabled |
-| subnets_ips | The IP and cidrs of the subnets being created |
-| subnets_names | The names of the subnets being created |
-| subnets_private_access | Whether the subnets will have access to Google API's without a public IP |
-| subnets_regions | The region where subnets will be created |
-| subnets_secondary_ranges | The secondary ranges associated with these subnets |
+| subnets\_flow\_logs | Whether the subnets will have VPC flow logs enabled |
+| subnets\_ips | The IP and cidrs of the subnets being created |
+| subnets\_names | The names of the subnets being created |
+| subnets\_private\_access | Whether the subnets will have access to Google API's without a public IP |
+| subnets\_regions | The region where subnets will be created |
+| subnets\_secondary\_ranges | The secondary ranges associated with these subnets |
 
 [^]: (autogen_docs_end)

--- a/examples/simple_project_with_regional_network/main.tf
+++ b/examples/simple_project_with_regional_network/main.tf
@@ -15,29 +15,24 @@
  */
 
 locals {
-  network_name = "test-network-${random_string.random_suffix.result}"
-}
-
-resource "random_string" "random_suffix" {
-  length  = 4
-  upper   = "false"
-  special = "false"
+  subnet_01 = "${var.network_name}-subnet-01"
+  subnet_02 = "${var.network_name}-subnet-02"
 }
 
 module "test-vpc-module" {
   source       = "../../"
   project_id   = "${var.project_id}"
-  network_name = "${local.network_name}"
+  network_name = "${var.network_name}"
   routing_mode = "REGIONAL"
 
   subnets = [
     {
-      subnet_name   = "subnet-11"
+      subnet_name   = "${local.subnet_01}"
       subnet_ip     = "10.10.10.0/24"
       subnet_region = "us-west1"
     },
     {
-      subnet_name           = "subnet-12"
+      subnet_name           = "${local.subnet_02}"
       subnet_ip             = "10.10.20.0/24"
       subnet_region         = "us-west1"
       subnet_private_access = "true"
@@ -46,7 +41,7 @@ module "test-vpc-module" {
   ]
 
   secondary_ranges = {
-    subnet-11 = []
-    subnet-12 = []
+    "${local.subnet_01}" = []
+    "${local.subnet_02}" = []
   }
 }

--- a/examples/simple_project_with_regional_network/variables.tf
+++ b/examples/simple_project_with_regional_network/variables.tf
@@ -17,3 +17,7 @@
 variable "project_id" {
   description = "The project ID to host the network in"
 }
+
+variable "network_name" {
+  description = "The name of the VPC network being created"
+}

--- a/test/ci_integration.sh
+++ b/test/ci_integration.sh
@@ -44,6 +44,8 @@ setup_environment() {
 
   # Terraform input variables
   export TF_VAR_project_id="${PROJECT_ID}"
+  TF_VAR_random_string_for_testing="${RANDOM_STRING_FOR_TESTING:-$(LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | fold -w 5 | head -n 1)}"
+  export TF_VAR_random_string_for_testing
 }
 
 main() {

--- a/test/fixtures/delete_default_gateway_routes/main.tf
+++ b/test/fixtures/delete_default_gateway_routes/main.tf
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
+locals {
+  network_name = "delete-gw-routes-${var.random_string_for_testing}"
+}
+
 module "example" {
-  source     = "../../../examples/delete_default_gateway_routes"
-  project_id = "${var.project_id}"
+  source       = "../../../examples/delete_default_gateway_routes"
+  project_id   = "${var.project_id}"
+  network_name = "${local.network_name}"
 }

--- a/test/fixtures/delete_default_gateway_routes/variables.tf
+++ b/test/fixtures/delete_default_gateway_routes/variables.tf
@@ -17,3 +17,7 @@
 variable "project_id" {
   description = "The GCP project to use for integration tests"
 }
+
+variable "random_string_for_testing" {
+  description = "A random string of characters to be appended to resource names to ensure uniqueness"
+}

--- a/test/fixtures/multi_vpc/main.tf
+++ b/test/fixtures/multi_vpc/main.tf
@@ -13,8 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+locals {
+  network_01_name = "multi-vpc-${var.random_string_for_testing}-01"
+  network_02_name = "multi-vpc-${var.random_string_for_testing}-02"
+}
 
 module "example" {
-  source     = "../../../examples/multi_vpc"
-  project_id = "${var.project_id}"
+  source          = "../../../examples/multi_vpc"
+  project_id      = "${var.project_id}"
+  network_01_name = "${local.network_01_name}"
+  network_02_name = "${local.network_02_name}"
 }

--- a/test/fixtures/multi_vpc/outputs.tf
+++ b/test/fixtures/multi_vpc/outputs.tf
@@ -18,3 +18,13 @@ output "project_id" {
   value       = "${var.project_id}"
   description = "The ID of the project being used"
 }
+
+output "network_01_name" {
+  value       = "${local.network_01_name}"
+  description = "The name of the VPC network-01"
+}
+
+output "network_02_name" {
+  value       = "${local.network_02_name}"
+  description = "The name of the VPC network-01"
+}

--- a/test/fixtures/secondary_ranges/main.tf
+++ b/test/fixtures/secondary_ranges/main.tf
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
+locals {
+  network_name = "secondary-ranges-${var.random_string_for_testing}"
+}
+
 module "example" {
-  source     = "../../../examples/secondary_ranges"
-  project_id = "${var.project_id}"
+  source       = "../../../examples/secondary_ranges"
+  project_id   = "${var.project_id}"
+  network_name = "${local.network_name}"
 }

--- a/test/fixtures/shared/variables.tf
+++ b/test/fixtures/shared/variables.tf
@@ -17,3 +17,7 @@
 variable "project_id" {
   description = "The GCP project to use for integration tests"
 }
+
+variable "random_string_for_testing" {
+  description = "A random string of characters to be appended to resource names to ensure uniqueness"
+}

--- a/test/fixtures/simple_project/main.tf
+++ b/test/fixtures/simple_project/main.tf
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
+locals {
+  network_name = "simple-project-${var.random_string_for_testing}"
+}
+
 module "example" {
-  source     = "../../../examples/simple_project"
-  project_id = "${var.project_id}"
+  source       = "../../../examples/simple_project"
+  project_id   = "${var.project_id}"
+  network_name = "${local.network_name}"
 }

--- a/test/fixtures/simple_project_with_regional_network/main.tf
+++ b/test/fixtures/simple_project_with_regional_network/main.tf
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
+locals {
+  network_name = "simple-regional-${var.random_string_for_testing}"
+}
+
 module "example" {
-  source     = "../../../examples/simple_project_with_regional_network"
-  project_id = "${var.project_id}"
+  source       = "../../../examples/simple_project_with_regional_network"
+  project_id   = "${var.project_id}"
+  network_name = "${local.network_name}"
 }

--- a/test/fixtures/simulated_ci_environment/README.md
+++ b/test/fixtures/simulated_ci_environment/README.md
@@ -6,40 +6,33 @@ of these resources is to run the integration tests locally as closely as
 possible to how they will run in the CI system.
 
 Once created, store the service account key content into the
-`GOOGLE_CREDENTIALS` environment variable.  This reflects the same behavior as
-used in CI.
+`SERVICE_ACCOUNT_JSON` environment variable. This reflects the same behavior
+as used in CI.
 
 For example:
 
 ```bash
 terraform init
 terraform apply
+mkdir -p ~/.credentials
 terraform output service_account_private_key > ~/.credentials/network-sa.json
 ```
 
 Then, configure the environment (suggest using direnv) like so:
 
 ```bash
-export GOOGLE_CREDENTIALS_PATH="${HOME}/.credentials/network-sa.json"
-export GOOGLE_CREDENTIALS="${HOME}/.credentials/network-sa.json"
-export TF_VAR_project_id="network-module"
+export SERVICE_ACCOUNT_JSON=$(cat ${HOME}/.credentials/network-sa.json)
+export PROJECT_ID="network-module"
 ```
 
-With these variables set, change to the root of the module and execute the `make test_integration` task.
-This make target is the same that is executed by this module's CI pipeline during integration testing, and
-will run the integration tests from your machine.
+With these variables set, change to the root of the module and execute the
+`make test_integration` task. This make target is the same that is executed
+by this module's CI pipeline during integration testing, and will run the
+integration tests from your machine.
 
-Alternatively, to run the integration tests directly from the Docker container used by the module's CI pipeline, copy
-the credentials file to the root of the module and then run the `make test_integration_docker` target:
-
-```
-# Change to the root of the module
-cd /path/to/module
-
-# Copy credentials and run test
-cp $GOOGLE_CREDENTIALS_PATH ./credentials.json
-make test_integration_docker
-```
+Alternatively, to run the integration tests directly from the Docker
+container used by the module's CI pipeline, perform the above steps and then
+run the `make test_integration_docker` target
 
 [^]: (autogen_docs_start)
 

--- a/test/fixtures/simulated_ci_environment/README.md
+++ b/test/fixtures/simulated_ci_environment/README.md
@@ -36,20 +36,19 @@ run the `make test_integration_docker` target
 
 [^]: (autogen_docs_start)
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| billing_account | The billing account id associated with the project, e.g. XXXXXX-YYYYYY-ZZZZZZ | string | - | yes |
-| folder_id | The numeric folder id to create resources | string | - | yes |
-| organization_id | The numeric organization id | string | - | yes |
-| region | The region to deploy to | string | `us-west1` | no |
+| billing\_account | The billing account id associated with the project, e.g. XXXXXX-YYYYYY-ZZZZZZ | string | n/a | yes |
+| folder\_id | The numeric folder id to create resources | string | n/a | yes |
+| organization\_id | The numeric organization id | string | n/a | yes |
+| region | The region to deploy to | string | `"us-west1"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| service_account_private_key | The SA KEY JSON content.  Store in GOOGLE_CREDENTIALS. |
+| service\_account\_private\_key | The SA KEY JSON content.  Store in GOOGLE_CREDENTIALS. |
 
 [^]: (autogen_docs_end)

--- a/test/integration/multi_vpc/controls/gcloud.rb
+++ b/test/integration/multi_vpc/controls/gcloud.rb
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project_id = attribute('project_id')
+project_id      = attribute('project_id')
+network_01_name = attribute('network_01_name')
+network_02_name = attribute('network_02_name')
 
 control "gcloud" do
   title "gcloud configuration"
 
-  describe command("gcloud compute routes describe test-network-301-egress-inet --project=#{project_id} --format=json") do
+  describe command("gcloud compute routes describe '#{network_01_name}-egress-inet' --project=#{project_id} --format=json") do
     its(:exit_status) { should eq 0 }
     its(:stderr) { should eq '' }
     let(:default_internet_gateway) { "https://www.googleapis.com/compute/v1/projects/#{project_id}/global/gateways/default-internet-gateway" }
@@ -49,7 +51,7 @@ control "gcloud" do
     end
   end
 
-  describe command("gcloud compute routes describe test-network-302-egress-inet --project=#{project_id} --format=json") do
+  describe command("gcloud compute routes describe '#{network_02_name}-egress-inet' --project=#{project_id} --format=json") do
     its(:exit_status) { should eq 0 }
     its(:stderr) { should eq '' }
     let(:default_internet_gateway) { "https://www.googleapis.com/compute/v1/projects/#{project_id}/global/gateways/default-internet-gateway" }
@@ -81,7 +83,7 @@ control "gcloud" do
     end
   end
 
-  describe command("gcloud compute routes describe test-network-302-testapp-proxy --project=#{project_id} --format=json") do
+  describe command("gcloud compute routes describe '#{network_02_name}-testapp-proxy' --project=#{project_id} --format=json") do
     its(:exit_status) { should eq 0 }
     its(:stderr) { should eq '' }
 

--- a/test/integration/multi_vpc/inspec.yml
+++ b/test/integration/multi_vpc/inspec.yml
@@ -1,5 +1,11 @@
-name: simple_project
+name: multi_vpc
 attributes:
   - name: project_id
+    required: true
+    type: string
+  - name: network_01_name
+    required: true
+    type: string
+  - name: network_02_name
     required: true
     type: string

--- a/test/integration/secondary_ranges/controls/gcloud.rb
+++ b/test/integration/secondary_ranges/controls/gcloud.rb
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project_id = attribute('project_id')
+project_id   = attribute('project_id')
+network_name = attribute('network_name')
 
 control "gcloud" do
   title "gcloud configuration"
 
-  describe command("gcloud compute networks subnets describe secondary-ranges-subnet-01 --project=#{project_id} --region=us-west1 --format=json") do
+  describe command("gcloud compute networks subnets describe #{network_name}-subnet-01 --project=#{project_id} --region=us-west1 --format=json") do
     its(:exit_status) { should eq 0 }
     its(:stderr) { should eq '' }
 
@@ -29,22 +30,22 @@ control "gcloud" do
       end
     end
 
-    it "should have the correct secondaryIpRanges configuration for secondary-ranges-subnet-01" do
+    it "should have the correct secondaryIpRanges configuration for #{network_name}-subnet-01-01" do
       expect(data["secondaryIpRanges"][0]).to include(
-        "rangeName"   => "subnet-01-01",
+        "rangeName"   => "#{network_name}-subnet-01-01",
         "ipCidrRange" => "192.168.64.0/24"
       )
     end
 
-    it "should have the correct secondaryIpRanges configuration for secondary-ranges-subnet-02" do
+    it "should have the correct secondaryIpRanges configuration for #{network_name}-subnet-01-02" do
       expect(data["secondaryIpRanges"][1]).to include(
-        "rangeName"   => "subnet-01-02",
+        "rangeName"   => "#{network_name}-subnet-01-02",
         "ipCidrRange" => "192.168.65.0/24"
       )
     end
   end
 
-  describe command("gcloud compute networks subnets describe secondary-ranges-subnet-03 --project=#{project_id} --region=us-west1 --format=json") do
+  describe command("gcloud compute networks subnets describe #{network_name}-subnet-03 --project=#{project_id} --region=us-west1 --format=json") do
     its(:exit_status) { should eq 0 }
     its(:stderr) { should eq '' }
 
@@ -56,9 +57,9 @@ control "gcloud" do
       end
     end
 
-    it "should have the correct secondaryIpRanges configuration for secondary-ranges-subnet-01" do
+    it "should have the correct secondaryIpRanges configuration for #{network_name}-subnet-03-01" do
       expect(data["secondaryIpRanges"][0]).to include(
-        "rangeName"   => "subnet-03-01",
+        "rangeName"   => "#{network_name}-subnet-03-01",
         "ipCidrRange" => "192.168.66.0/24"
       )
     end

--- a/test/integration/secondary_ranges/inspec.yml
+++ b/test/integration/secondary_ranges/inspec.yml
@@ -3,3 +3,6 @@ attributes:
   - name: project_id
     required: true
     type: string
+  - name: network_name
+    required: true
+    type: string

--- a/test/integration/simple_project/controls/gcloud.rb
+++ b/test/integration/simple_project/controls/gcloud.rb
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project_id = attribute('project_id')
+project_id   = attribute('project_id')
+network_name = attribute('network_name')
 
 control "gcloud" do
   title "gcloud configuration"
 
-  describe command("gcloud compute networks subnets describe subnet-01 --project=#{project_id} --region=us-west1 --format=json") do
+  describe command("gcloud compute networks subnets describe #{network_name}-subnet-01 --project=#{project_id} --region=us-west1 --format=json") do
     its(:exit_status) { should eq 0 }
     its(:stderr) { should eq '' }
 
@@ -38,7 +39,7 @@ control "gcloud" do
     end
   end
 
-  describe command("gcloud compute networks subnets describe subnet-02 --project=#{project_id} --region=us-west1 --format=json") do
+  describe command("gcloud compute networks subnets describe #{network_name}-subnet-02 --project=#{project_id} --region=us-west1 --format=json") do
     its(:exit_status) { should eq 0 }
     its(:stderr) { should eq '' }
 

--- a/test/integration/simple_project/controls/gcp.rb
+++ b/test/integration/simple_project/controls/gcp.rb
@@ -27,7 +27,7 @@ control "gcp" do
 
   describe google_compute_subnetwork(
     project: project_id,
-    name: "subnet-01",
+    name: "#{network_name}-subnet-01",
     region: "us-west1"
   ) do
     it { should exist }
@@ -37,7 +37,7 @@ control "gcp" do
 
   describe google_compute_subnetwork(
     project: project_id,
-    name: "subnet-02",
+    name: "#{network_name}-subnet-02",
     region: "us-west1"
   ) do
     it { should exist }


### PR DESCRIPTION
This commit updates the integration test fixtures to allow for
randomized subnetwork names as well as randomized network names. Without
this commit the integration test fixtures will create VPC networks with
randomized names, but the subnetwork names will remain static. Because
subnetworks are regional resources, you can't have two subnetworks with
the same name tied to the same project and region. This means that
without adding randomness to subnetwork names, only 1 run of the
integration test pipeline can occur at any given time.

Normally a `random_string` resource is used to impart randomness into
resource names, but because of the way lookups are performed on the
`subnets` and `secondary_ranges` input variables, those variables cannot
contain computed values. To remedy this the test fixtures in
`test/fixtures/<scenario name>` now include an input variable named
`random_string_for_testing` that accepts a string to be appended on both
the network and subnetwork names. The `test/ci_integration.sh` script
has been modified to look for an environment variable named
`RANDOM_STRING_FOR_TESTING` and pass that to
`var.random_string_for_testing`. If that environment variable has not
been declared then a 5-character string is generated on the fly and
used.

This commit also contains an update to `Makefile` to ensure that
`test/ci_integration.sh` is sourced and the `setup_environment()`
function is called for any of the `docker_*` make targets. The
`Makefile` has also been modified to ensure that the environment
variables that are referenced by `test/ci_integration.sh` are being
passed down to the Docker container.