### PR TITLE
Ensure that Compute Engine API is enabled on host project

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,15 @@
  */
 
 /******************************************
+	Enable compute engine services on project
+ *****************************************/
+resource "google_project_service" "compute_engine_service" {
+  project                    = "${var.project_id}"
+  service                    = "compute.googleapis.com"
+  disable_dependent_services = true
+}
+
+/******************************************
 	VPC configuration
  *****************************************/
 resource "google_compute_network" "network" {
@@ -28,10 +37,9 @@ resource "google_compute_network" "network" {
 	Shared VPC
  *****************************************/
 resource "google_compute_shared_vpc_host_project" "shared_vpc_host" {
-  count   = "${var.shared_vpc_host == "true" ? 1 : 0}"
-  project = "${var.project_id}"
+  count      = "${var.shared_vpc_host == "true" ? 1 : 0}"
+  project    = "${var.project_id}"
   depends_on = ["google_compute_network.network"]
-
 }
 
 /******************************************


### PR DESCRIPTION
I have the issue where this terraform-google-network module is trying to create the VPC when the compute.googleapis.com has not yet been fully activated on the host project created by the project-factory module.

My main.tf of my vpc module looks like this, and I call it 3 times to create 3 different networks:
```
module "vpc_project" {
  source                      = "terraform-google-modules/project-factory/google"
  version                     = "2.1.1"
  disable_services_on_destroy = "false"
  auto_create_network         = "true"
  org_id                      = "${var.org_id}"
  name                        = "${local.project_name}"
  project_id                  = "${local.project_name}"
  labels                      = "${var.labels}"
  folder_id                   = "${var.folder_id}"
  billing_account             = "${var.billing_account}"

  activate_apis = [
    "compute.googleapis.com",
  ]
}

module "vpc" {
  source                                 = "terraform-google-modules/network/google"
  version                                = "0.6.0"
  delete_default_internet_gateway_routes = "true"
  project_id                             = "${module.vpc_project.project_id}"
  network_name                           = "${local.network_name}"
  routing_mode                           = "${var.routing_mode}"
  shared_vpc_host                        = "${var.shared_vpc_host}"
  subnets                                = ["${var.subnets}"]
  secondary_ranges                       = "${var.secondary_ranges}"
  routes                                 = ["${var.routes}"]
}
```

When I `terraform apply --auto-approve` I get the error below:
```
6 error(s) occurred:

* module.core.module.vpc_prod.module.vpc.google_compute_shared_vpc_host_project.shared_vpc_host: 1 error(s) occurred:

* google_compute_shared_vpc_host_project.shared_vpc_host: Error enabling Shared VPC Host "gcp-demo006-vpchost-prod": googleapi: Error 403: Project 990078659764 is not found and cannot be used for API calls. If it is recently created, enable Compute Engine API by visiting https://console.developers.google.com/apis/api/compute.googleapis.com/overview?project=990078659764 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry., accessNotConfigured
* module.core.module.vpc_prod.module.vpc.google_compute_network.network: 1 error(s) occurred:

* google_compute_network.network: Error creating Network: googleapi: Error 403: Project 990078659764 is not found and cannot be used for API calls. If it is recently created, enable Compute Engine API by visiting https://console.developers.google.com/apis/api/compute.googleapis.com/overview?project=990078659764 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry., accessNotConfigured
* module.core.module.vpc_sharedservices.module.vpc.google_compute_network.network: 1 error(s) occurred:

* google_compute_network.network: Error creating Network: googleapi: Error 403: Project 521117496139 is not found and cannot be used for API calls. If it is recently created, enable Compute Engine API by visiting https://console.developers.google.com/apis/api/compute.googleapis.com/overview?project=521117496139 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry., accessNotConfigured
* module.core.module.vpc_sharedservices.module.vpc.google_compute_shared_vpc_host_project.shared_vpc_host: 1 error(s) occurred:

* google_compute_shared_vpc_host_project.shared_vpc_host: Error enabling Shared VPC Host "gcp-demo006-vpchost-sharedsvc": googleapi: Error 403: Project 521117496139 is not found and cannot be used for API calls. If it is recently created, enable Compute Engine API by visiting https://console.developers.google.com/apis/api/compute.googleapis.com/overview?project=521117496139 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry., accessNotConfigured
* module.core.module.vpc_nonprod.module.vpc.google_compute_network.network: 1 error(s) occurred:

* google_compute_network.network: Error creating Network: googleapi: Error 403: Project 1089100137307 is not found and cannot be used for API calls. If it is recently created, enable Compute Engine API by visiting https://console.developers.google.com/apis/api/compute.googleapis.com/overview?project=1089100137307 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry., accessNotConfigured
* module.core.module.vpc_nonprod.module.vpc.google_compute_shared_vpc_host_project.shared_vpc_host: 1 error(s) occurred:

* google_compute_shared_vpc_host_project.shared_vpc_host: Error enabling Shared VPC Host "gcp-demo006-vpchost-nonprod": googleapi: Error 403: Project 1089100137307 is not found and cannot be used for API calls. If it is recently created, enable Compute Engine API by visiting https://console.developers.google.com/apis/api/compute.googleapis.com/overview?project=1089100137307 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry., accessNotConfigured

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```

This is resolved when I reconfirm that the `compute.googleapis.com` is enabled before creating the VPC.