### PR TITLE
Initial import of net-firewall submodule from internal version.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -93,3 +93,20 @@ suites:
           backend: local
           controls:
             - gcloud
+  - name: "submodule_firewall"
+    driver:
+      name: "terraform"
+      command_timeout: 1800
+      root_module_directory: test/fixtures/submodule_firewall/
+    verifier:
+      name: terraform
+      color: true
+      systems:
+        - name: inspec-gcp
+          backend: gcp
+          controls:
+            - gcp
+        - name: local
+          backend: local
+          controls:
+            - gcloud

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning][semver-site].
 
 ## [Unreleased]
 
+### Added
+
+- New firewall submodule [#40]
+
 ## [0.6.0] - 2019-02-21
 
 ### Added

--- a/examples/submodule_firewall/README.md
+++ b/examples/submodule_firewall/README.md
@@ -1,0 +1,30 @@
+# Simple Project
+
+This example configures a single simple VPC inside of a project.
+
+This VPC has two subnets, with no secondary ranges.
+
+[^]: (autogen_docs_start)
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| network\_name | The name of the VPC network being created | string | n/a | yes |
+| project\_id | The project ID to host the network in | string | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| network\_name | The name of the VPC being created |
+| network\_self\_link | The URI of the VPC being created |
+| routes | The routes associated with this VPC |
+| subnets\_flow\_logs | Whether the subnets will have VPC flow logs enabled |
+| subnets\_ips | The IP and cidrs of the subnets being created |
+| subnets\_names | The names of the subnets being created |
+| subnets\_private\_access | Whether the subnets will have access to Google API's without a public IP |
+| subnets\_regions | The region where subnets will be created |
+| subnets\_secondary\_ranges | The secondary ranges associated with these subnets |
+
+[^]: (autogen_docs_end)

--- a/examples/submodule_firewall/README.md
+++ b/examples/submodule_firewall/README.md
@@ -1,6 +1,6 @@
-# Simple Project
+# Simple Project With Firewall
 
-This example configures a single simple VPC inside of a project.
+This example configures a single simple VPC inside of a project, and adds a basic firewall.
 
 This VPC has two subnets, with no secondary ranges.
 
@@ -17,14 +17,8 @@ This VPC has two subnets, with no secondary ranges.
 
 | Name | Description |
 |------|-------------|
+| admin\_ranges | Firewall attributes for admin ranges. |
+| internal\_ranges | Firewall attributes for internal ranges. |
 | network\_name | The name of the VPC being created |
-| network\_self\_link | The URI of the VPC being created |
-| routes | The routes associated with this VPC |
-| subnets\_flow\_logs | Whether the subnets will have VPC flow logs enabled |
-| subnets\_ips | The IP and cidrs of the subnets being created |
-| subnets\_names | The names of the subnets being created |
-| subnets\_private\_access | Whether the subnets will have access to Google API's without a public IP |
-| subnets\_regions | The region where subnets will be created |
-| subnets\_secondary\_ranges | The secondary ranges associated with these subnets |
 
 [^]: (autogen_docs_end)

--- a/examples/submodule_firewall/main.tf
+++ b/examples/submodule_firewall/main.tf
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+locals {
+  subnet_01 = "${var.network_name}-subnet-01"
+  subnet_02 = "${var.network_name}-subnet-02"
+}
+
+module "test-vpc-module" {
+  source       = "../../"
+  project_id   = "${var.project_id}"
+  network_name = "${var.network_name}"
+
+  subnets = [
+    {
+      subnet_name   = "${local.subnet_01}"
+      subnet_ip     = "10.10.10.0/24"
+      subnet_region = "us-west1"
+    },
+    {
+      subnet_name           = "${local.subnet_02}"
+      subnet_ip             = "10.10.20.0/24"
+      subnet_region         = "us-west1"
+      subnet_private_access = "true"
+      subnet_flow_logs      = "true"
+    },
+  ]
+
+  secondary_ranges = {
+    "${local.subnet_01}" = []
+    "${local.subnet_02}" = []
+  }
+}
+
+module "test-firewall-submodule" {
+  source                  = "../../modules/fabric-net-firewall"
+  project_id              = "${var.project_id}"
+  network                 = "${module.test-vpc-module.network_name}"
+  internal_ranges_enabled = true
+  internal_ranges         = ["${module.test-vpc-module.subnets_ips}"]
+
+  internal_allow = [{
+    protocol = "icmp"
+  },
+    {
+      protocol = "tcp"
+    },
+    {
+      protocol = "udp"
+    },
+  ]
+}

--- a/examples/submodule_firewall/outputs.tf
+++ b/examples/submodule_firewall/outputs.tf
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "network_name" {
+  value       = "${module.test-vpc-module.network_name}"
+  description = "The name of the VPC being created"
+}
+
+output "internal_ranges" {
+  description = "Firewall attributes for internal ranges."
+  value       = "${module.test-firewall-submodule.internal_ranges}"
+}
+
+output "admin_ranges" {
+  description = "Firewall attributes for admin ranges."
+  value       = "${module.test-firewall-submodule.admin_ranges}"
+}

--- a/examples/submodule_firewall/variables.tf
+++ b/examples/submodule_firewall/variables.tf
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The project ID to host the network in"
+}
+
+variable "network_name" {
+  description = "The name of the VPC network being created"
+}

--- a/helpers/combine_docfiles.py
+++ b/helpers/combine_docfiles.py
@@ -54,10 +54,6 @@ groups = re.match(
 replace_content = groups[0] + groups[1]
 
 # Find where to put the replacement content, overwrite the input file
-m = re.match(insert_separator_regex, input, re.DOTALL)
-if not m:
-  print("insert regexp not matched in %s" % sys.argv[1])
-  sys.exit(0)
-groups = m.groups(0)
+groups = re.match(insert_separator_regex, input, re.DOTALL).groups(0)
 output = groups[0] + replace_content + groups[2] + "\n"
 open(sys.argv[1], "w").write(output)

--- a/helpers/combine_docfiles.py
+++ b/helpers/combine_docfiles.py
@@ -54,6 +54,10 @@ groups = re.match(
 replace_content = groups[0] + groups[1]
 
 # Find where to put the replacement content, overwrite the input file
-groups = re.match(insert_separator_regex, input, re.DOTALL).groups(0)
+m = re.match(insert_separator_regex, input, re.DOTALL)
+if not m:
+  print("insert regexp not matched in %s" % sys.argv[1])
+  sys.exit(0)
+groups = m.groups(0)
 output = groups[0] + replace_content + groups[2] + "\n"
 open(sys.argv[1], "w").write(output)

--- a/modules/fabric-net-firewall/README.md
+++ b/modules/fabric-net-firewall/README.md
@@ -1,0 +1,56 @@
+# Google Cloud Simple VPC Firewall Creation
+
+This module allows creation of a minimal VPC firewall, supporting basic configurable rules for IP range-based intra-VPC and administrator ingress, and tag-based SSH, HTTP, and HTTPS ingress.
+
+The HTTP and HTTPS rules use the same network tags network tags that are assigned to instances when flaggging the "Allow HTTP[S] traffic" checkbox in the Cloud Console. The SSH rule uses a generic `ssh` tag.
+
+All IP source ranges are configurable through variables, and are set by default to `0.0.0.0/0` for tag-based rules. Allowed protocols and/or ports for the intra-VPC rule are also configurable through a variable.
+
+The resources created/managed by this module are:
+
+- one optional ingress rule from internal CIDR ranges, only allowing ICMP by default
+- one optional ingress rule from admin CIDR ranges, allowing all protocols on all ports
+- one optional ingress rule for SSH on network tag `ssh`
+- one optional ingress rule for HTTP on network tag `http-server`
+- one optional ingress rule for HTTPS on network tag `https-server`
+
+
+## Usage
+
+Basic usage of this module is as follows:
+
+```hcl
+module "net-firewall" {
+  source                  = "terraform-google-modules/terraform-google-network/google//modules/fabric-net-firewall"
+  project_id              = "my-project"
+  network                 = "my-vpc"
+  internal_ranges_enabled = true
+  internal_ranges         = ["10.0.0.0/0"]
+}
+```
+
+[^]: (autogen_docs_start)
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| admin\_ranges | IP CIDR ranges that have complete access to all subnets. | list | `<list>` | no |
+| admin\_ranges\_enabled | Enable admin ranges-based rules. | string | `"false"` | no |
+| http\_source\_ranges | List of IP CIDR ranges for tag-based HTTP rule, defaults to 0.0.0.0/0. | list | `<list>` | no |
+| https\_source\_ranges | List of IP CIDR ranges for tag-based HTTPS rule, defaults to 0.0.0.0/0. | list | `<list>` | no |
+| internal\_allow | Allow rules for internal ranges. | list | `<list>` | no |
+| internal\_ranges | IP CIDR ranges for intra-VPC rules. | list | `<list>` | no |
+| internal\_ranges\_enabled | Create rules for intra-VPC ranges. | string | `"false"` | no |
+| network | Name of the network this set of firewall rules applies to. | string | n/a | yes |
+| project\_id | Project id of the project that holds the network. | string | n/a | yes |
+| ssh\_source\_ranges | List of IP CIDR ranges for tag-based SSH rule, defaults to 0.0.0.0/0. | list | `<list>` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| admin\_ranges | Admin ranges data. |
+| internal\_ranges | Internal ranges data. |
+
+[^]: (autogen_docs_end)

--- a/modules/fabric-net-firewall/README.md
+++ b/modules/fabric-net-firewall/README.md
@@ -51,6 +51,6 @@ module "net-firewall" {
 | Name | Description |
 |------|-------------|
 | admin\_ranges | Admin ranges data. |
-| internal\_ranges | Internal ranges data. |
+| internal\_ranges | Internal ranges. |
 
 [^]: (autogen_docs_end)

--- a/modules/fabric-net-firewall/main.tf
+++ b/modules/fabric-net-firewall/main.tf
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+###############################################################################
+#                            rules based on IP ranges
+###############################################################################
+
+resource "google_compute_firewall" "allow-internal" {
+  count         = "${var.internal_ranges_enabled && length(var.internal_allow) > 0 ? 1 : 0}"
+  name          = "${var.network}-ingress-internal"
+  description   = "Allow ingress traffic from internal IP ranges"
+  network       = "${var.network}"
+  project       = "${var.project_id}"
+  source_ranges = ["${var.internal_ranges}"]
+  allow         = ["${var.internal_allow}"]
+}
+
+resource "google_compute_firewall" "allow-admins" {
+  count         = "${var.admin_ranges_enabled > 0 ? 1 : 0}"
+  name          = "${var.network}-ingress-admins"
+  description   = "Access from the admin subnet to all subnets"
+  network       = "${var.network}"
+  project       = "${var.project_id}"
+  source_ranges = ["${var.admin_ranges}"]
+
+  allow {
+    protocol = "icmp"
+  }
+
+  allow {
+    protocol = "tcp"
+  }
+
+  allow {
+    protocol = "udp"
+  }
+}
+
+###############################################################################
+#                              rules based on tags
+###############################################################################
+
+resource "google_compute_firewall" "allow-tag-ssh" {
+  count         = "${length(var.ssh_source_ranges) > 0 ? 1 : 0}"
+  name          = "${var.network}-ingress-tag-ssh"
+  description   = "Allow SSH to machines with the 'ssh' tag"
+  network       = "${var.network}"
+  project       = "${var.project_id}"
+  source_ranges = ["${var.ssh_source_ranges}"]
+  target_tags   = ["ssh"]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+}
+
+resource "google_compute_firewall" "allow-tag-http" {
+  count         = "${length(var.http_source_ranges) > 0 ? 1 : 0}"
+  name          = "${var.network}-ingress-tag-http"
+  description   = "Allow HTTP to machines with the 'http-server' tag"
+  network       = "${var.network}"
+  project       = "${var.project_id}"
+  source_ranges = ["${var.http_source_ranges}"]
+  target_tags   = ["http-server"]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["80"]
+  }
+}
+
+resource "google_compute_firewall" "allow-tag-https" {
+  count         = "${length(var.https_source_ranges) > 0 ? 1 : 0}"
+  name          = "${var.network}-ingress-tag-https"
+  description   = "Allow HTTPS to machines with the 'https' tag"
+  network       = "${var.network}"
+  project       = "${var.project_id}"
+  source_ranges = ["${var.https_source_ranges}"]
+  target_tags   = ["https-server"]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["443"]
+  }
+}

--- a/modules/fabric-net-firewall/outputs.tf
+++ b/modules/fabric-net-firewall/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/fabric-net-firewall/outputs.tf
+++ b/modules/fabric-net-firewall/outputs.tf
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "internal_ranges" {
+  description = "Internal ranges."
+
+  value = {
+    enabled = "${var.internal_ranges_enabled}"
+    ranges  = "${var.internal_ranges_enabled ? join(",", var.internal_ranges) : ""}"
+  }
+}
+
+output "admin_ranges" {
+  description = "Admin ranges data."
+
+  value = {
+    enabled = "${var.admin_ranges_enabled}"
+    ranges  = "${var.admin_ranges_enabled ? join(",", var.admin_ranges) : ""}"
+  }
+}

--- a/modules/fabric-net-firewall/variables.tf
+++ b/modules/fabric-net-firewall/variables.tf
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "network" {
+  description = "Name of the network this set of firewall rules applies to."
+}
+
+variable "project_id" {
+  description = "Project id of the project that holds the network."
+}
+
+variable "internal_ranges_enabled" {
+  description = "Create rules for intra-VPC ranges."
+  default     = false
+}
+
+variable "internal_ranges" {
+  description = "IP CIDR ranges for intra-VPC rules."
+  default     = []
+}
+
+variable "internal_allow" {
+  description = "Allow rules for internal ranges."
+
+  default = [
+    {
+      protocol = "icmp"
+    },
+  ]
+}
+
+variable "admin_ranges_enabled" {
+  description = "Enable admin ranges-based rules."
+  default     = false
+}
+
+variable "admin_ranges" {
+  description = "IP CIDR ranges that have complete access to all subnets."
+  default     = []
+}
+
+variable "ssh_source_ranges" {
+  description = "List of IP CIDR ranges for tag-based SSH rule, defaults to 0.0.0.0/0."
+  default     = ["0.0.0.0/0"]
+}
+
+variable "http_source_ranges" {
+  description = "List of IP CIDR ranges for tag-based HTTP rule, defaults to 0.0.0.0/0."
+  default     = ["0.0.0.0/0"]
+}
+
+variable "https_source_ranges" {
+  description = "List of IP CIDR ranges for tag-based HTTPS rule, defaults to 0.0.0.0/0."
+  default     = ["0.0.0.0/0"]
+}

--- a/test/fixtures/submodule_firewall/main.tf
+++ b/test/fixtures/submodule_firewall/main.tf
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  network_name = "simple-project-${var.random_string_for_testing}"
+}
+
+module "example" {
+  source       = "../../../examples/submodule_firewall"
+  project_id   = "${var.project_id}"
+  network_name = "${local.network_name}"
+}

--- a/test/fixtures/submodule_firewall/main.tf
+++ b/test/fixtures/submodule_firewall/main.tf
@@ -15,7 +15,7 @@
  */
 
 locals {
-  network_name = "simple-project-${var.random_string_for_testing}"
+  network_name = "submodule-firewall-${var.random_string_for_testing}"
 }
 
 module "example" {

--- a/test/fixtures/submodule_firewall/outputs.tf
+++ b/test/fixtures/submodule_firewall/outputs.tf
@@ -1,0 +1,1 @@
+../shared/outputs.tf

--- a/test/fixtures/submodule_firewall/terraform.tfvars
+++ b/test/fixtures/submodule_firewall/terraform.tfvars
@@ -1,0 +1,1 @@
+../shared/terraform.tfvars

--- a/test/fixtures/submodule_firewall/variables.tf
+++ b/test/fixtures/submodule_firewall/variables.tf
@@ -1,0 +1,1 @@
+../shared/variables.tf

--- a/test/integration/simple_project/inspec.yml
+++ b/test/integration/simple_project/inspec.yml
@@ -2,7 +2,7 @@ name: simple_project
 depends:
   - name: inspec-gcp
     git: https://github.com/inspec/inspec-gcp.git
-    version: ~> 0.11.0
+    tag: v0.11.0
 attributes:
   - name: project_id
     required: true

--- a/test/integration/simple_project/inspec.yml
+++ b/test/integration/simple_project/inspec.yml
@@ -2,7 +2,7 @@ name: simple_project
 depends:
   - name: inspec-gcp
     git: https://github.com/inspec/inspec-gcp.git
-    version: ~> 0.9.0
+    version: ~> 0.11.0
 attributes:
   - name: project_id
     required: true

--- a/test/integration/simple_project_with_regional_network/inspec.yml
+++ b/test/integration/simple_project_with_regional_network/inspec.yml
@@ -2,7 +2,7 @@ name: simple_project_with_regional_network
 depends:
   - name: inspec-gcp
     git: https://github.com/inspec/inspec-gcp.git
-    version: ~> 0.9.0
+    version: ~> 0.11.0
 attributes:
   - name: project_id
     required: true

--- a/test/integration/simple_project_with_regional_network/inspec.yml
+++ b/test/integration/simple_project_with_regional_network/inspec.yml
@@ -2,7 +2,7 @@ name: simple_project_with_regional_network
 depends:
   - name: inspec-gcp
     git: https://github.com/inspec/inspec-gcp.git
-    version: ~> 0.11.0
+    tag: v0.11.0
 attributes:
   - name: project_id
     required: true

--- a/test/integration/submodule_firewall/controls/gcloud.rb
+++ b/test/integration/submodule_firewall/controls/gcloud.rb
@@ -1,0 +1,43 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project_id   = attribute('project_id')
+network_name = attribute('network_name')
+
+control "gcloud" do
+  title "gcloud configuration"
+
+  describe command("gcloud compute firewall-rules describe #{network_name}-ingress-internal --project=#{project_id} --format=json") do
+    its(:exit_status) { should eq 0 }
+    its(:stderr) { should eq '' }
+
+    let(:data) do
+      if subject.exit_status == 0
+        JSON.parse(subject.stdout)
+      else
+        {}
+      end
+    end
+
+    describe "internal rule" do
+      it "should exist" do
+        expect(data).to include(
+          "sourceRanges" => ["10.10.20.0/24", "10.10.10.0/24"]
+        )
+      end
+    end
+
+  end
+
+end

--- a/test/integration/submodule_firewall/controls/gcp.rb
+++ b/test/integration/submodule_firewall/controls/gcp.rb
@@ -1,0 +1,29 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project_id   = attribute('project_id')
+network_name = attribute('network_name')
+
+control "gcp" do
+  title "Google Cloud configuration"
+
+  describe google_compute_firewalls(project: project_id) do
+    its('firewall_names') { should include "#{network_name}-ingress-internal" }
+    its('firewall_names') { should include "#{network_name}-ingress-tag-http" }
+    its('firewall_names') { should include "#{network_name}-ingress-tag-https" }
+    its('firewall_names') { should include "#{network_name}-ingress-tag-ssh" }
+    its('firewall_names') { should_not include "default-ingress-admins" }
+  end
+
+end

--- a/test/integration/submodule_firewall/inspec.yml
+++ b/test/integration/submodule_firewall/inspec.yml
@@ -2,7 +2,7 @@ name: simple_project
 depends:
   - name: inspec-gcp
     git: https://github.com/inspec/inspec-gcp.git
-    version: ~> 0.11.0
+    tag: v0.11.0
 attributes:
   - name: project_id
     required: true

--- a/test/integration/submodule_firewall/inspec.yml
+++ b/test/integration/submodule_firewall/inspec.yml
@@ -1,0 +1,12 @@
+name: simple_project
+depends:
+  - name: inspec-gcp
+    git: https://github.com/inspec/inspec-gcp.git
+    version: ~> 0.11.0
+attributes:
+  - name: project_id
+    required: true
+    type: string
+  - name: network_name
+    required: true
+    type: string


### PR DESCRIPTION
This brings in the net-firewall module as a submodule.

I added a new example and tests, as I was not too sure that adding the submodule to the simple example was fine.

I'm not too sure about the version bump in `inspec.yml`, but it's the only way I could run verify witout Kitchen complaining about a version mismatch.

This PR also contains a minimal fix to the combine docfiles script, so it doesn't fail when a match is not found (as happens in this repo).

