### PR TITLE
Add support for shared vpc service project attachment

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,16 +35,18 @@ resource "google_compute_shared_vpc_host_project" "shared_vpc_host" {
 
 resource "google_compute_shared_vpc_service_project" "projects" {
   count           = "${var.shared_vpc_host == "true" ? var.shared_vpc_service_projects_num : 0}"
-  host_project    = "host-project-id"
-  service_project = "${element(var.shared_vpc_service_projects, count.index)}"
+  host_project    = "${var.project_id}"
+  service_project = "${var.shared_vpc_service_projects[count.index]}"
   depends_on      = ["google_compute_shared_vpc_host_project.shared_vpc_host"]
 }
 
 resource "google_compute_subnetwork_iam_binding" "subnets" {
-  count      = "${var.shared_vpc_host == "true" ? length(var.shared_vpc_iam_subnets) : 0}"
-  subnetwork = "${element(var.shared_vpc_iam_subnets, count.index)}"
+  count      = "${var.shared_vpc_host == "true" ? length(var.shared_vpc_iam_subnet_names) : 0}"
+  project    = "${var.project_id}"
+  region     = "${lookup(var.shared_vpc_iam_subnets[count.index], "region")}"
+  subnetwork = "${var.shared_vpc_iam_subnet_names[count.index]}"
   role       = "roles/compute.networkUser"
-  members    = ["${split(",", element(var.shared_vpc_iam_members, count.index))}"]
+  members    = ["${split(",", lookup(var.shared_vpc_iam_subnets[count.index], "members"))}"]
   depends_on = ["google_compute_shared_vpc_host_project.shared_vpc_host"]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -54,3 +54,26 @@ variable "delete_default_internet_gateway_routes" {
   description = "If set, ensure that all routes within the network specified whose names begin with 'default-route' and with a next hop of 'default-internet-gateway' are deleted"
   default     = "false"
 }
+
+# allow controlling shared VPC project attachment or subnet access
+# passed-in values can be dynamic, so variables used in count need to be separate
+
+variable "shared_vpc_service_projects_num" {
+  description = "Number of service projects that will get full access to the shared VPC."
+  default     = 0
+}
+
+variable "shared_vpc_service_projects" {
+  description = "Service projects that will get full access to the shared VPC."
+  default     = []
+}
+
+variable "shared_vpc_iam_subnets" {
+  description = "Names of subnets on which to grant network user roles."
+  default     = []
+}
+
+variable "shared_vpc_iam_members" {
+  description = "Comma-delimited members that will be granted network user roles, one per subnet."
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -68,12 +68,12 @@ variable "shared_vpc_service_projects" {
   default     = []
 }
 
-variable "shared_vpc_iam_subnets" {
+variable "shared_vpc_iam_subnet_names" {
   description = "Names of subnets on which to grant network user roles."
   default     = []
 }
 
-variable "shared_vpc_iam_members" {
-  description = "Comma-delimited members that will be granted network user roles, one per subnet."
+variable "shared_vpc_iam_subnets" {
+  description = "List of one map per subnet, each with a 'region' key and a 'members' key with comma-delimited IAM-style members."
   default     = []
 }


### PR DESCRIPTION
This adds support for attaching service projects to shared VPC, at the network or subnetwork level.

We need this for Fabric environments, where the logical place to declare service projects is at the network resource stage, instead of the project stage like project factory does (and we're not using project factory in fabric environments, but our simplified project submodule).

My strong preference would be to implement this into a separate submodule, which is unfortunately not possible due to the dependency on the `google_compute_shared_vpc_host_project` resource, and I could not find a way of doing that through outputs, as the resource only exposes the attributes that are passed in to it. If you have a sane way of doing it, let's explore it.

The other complexity derives from the fact that most of the variables needed for project atachment are dynamic when, as in Fabric environments, projects are created in the same root module: project ids, service accounts which are derived from project numbers, etc. This means that none of those variables can be used in counts, to avoid the dreaded "value of count cannot be computed" error, making variables design sub-optimal.

That said the code is not elegant but very simple (two resources with count), and is only used when `shared_vpc_host` is true. I have no way of testing it as it requires at least one more project, but I tested it locally and it works.

I'm open to other suggestions, but given the above constraints this looks like the best place to implement it. And of course, not having this available is blocking progress on the Fabric environments.