### PR TITLE
Second take at Shared VPC configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Then perform the following commands on the root folder:
 | subnets\_regions | The region where the subnets will be created |
 | subnets\_secondary\_ranges | The secondary ranges associated with these subnets |
 | subnets\_self\_links | The self-links of subnets being created |
+| svpc\_host\_project\_id | Shared VPC host project id. |
 
 [^]: (autogen_docs_end)
 

--- a/examples/submodule_svpc_access/README.md
+++ b/examples/submodule_svpc_access/README.md
@@ -6,7 +6,7 @@ The VPC has two subnets with no secondary ranges, service projects are configure
 
 - the first service project is granted VPC-level access
 - the second service project is granted subnet-level access to the second subnet
-- the this service project is granted subnet-level access to the first and second subnet
+- the third service project is granted subnet-level access to the first and second subnet
 
 Subnet-level access in this example is only granted to the default GCE service accounts for illustrative purposes. More realistic examples should grant access to other service accounts (possibly including the GKE robot service accounts as per [documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc)), and project users/groups that need to use the Shared VPC from other projects (eg to create VMs).
 

--- a/examples/submodule_svpc_access/README.md
+++ b/examples/submodule_svpc_access/README.md
@@ -1,0 +1,25 @@
+# Shared VPC with service projects
+
+This simple example configures a shared VPC, and grants access to it to service projects.
+
+The VPC has two subnets with no secondary ranges, service projects are configured as follows:
+
+- the first service project is granted VPC-level access
+- the second service project is granted subnet-level access to the second subnet
+- the this service project is granted subnet-level access to the first and second subnet
+
+Subnet-level access in this example is only granted to the default GCE service accounts for illustrative purposes. More realistic examples should grant access to other service accounts (possibly including the GKE robot service accounts as per [documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc)), and project users/groups that need to use the Shared VPC from other projects (eg to create VMs).
+
+[^]: (autogen_docs_start)
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| host\_project\_id | Id of the host project where the shared VPC will be created. | string | n/a | yes |
+| network\_name | Name of the shared VPC. | string | `"test-svpc"` | no |
+| service\_project\_id\_full\_access | Id of the service project that will get VPC-level access. | string | n/a | yes |
+| service\_project\_number\_first\_subnet | Project number to derive service accounts with access to first subnet. | string | n/a | yes |
+| service\_project\_number\_multi\_subnet | Project number to derive service accounts with access to first and second subnet. | string | n/a | yes |
+
+[^]: (autogen_docs_end)

--- a/examples/submodule_svpc_access/main.tf
+++ b/examples/submodule_svpc_access/main.tf
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  first_gce_sa  = "serviceAccount:${var.service_project_number_first_subnet}-compute@developer.gserviceaccount.com"
+  second_gce_sa = "serviceAccount:${var.service_project_number_multi_subnet}-compute@developer.gserviceaccount.com"
+}
+
+module "net-vpc-shared" {
+  source          = "../../"
+  project_id      = "${var.host_project_id}"
+  network_name    = "${var.network_name}"
+  shared_vpc_host = "true"
+
+  subnets = [
+    {
+      subnet_name   = "first"
+      subnet_ip     = "10.10.10.0/24"
+      subnet_region = "europe-west1"
+    },
+    {
+      subnet_name   = "second"
+      subnet_ip     = "10.10.20.0/24"
+      subnet_region = "europe-west1"
+    },
+  ]
+
+  secondary_ranges = {
+    first  = []
+    second = []
+  }
+}
+
+module "net-svpc-access" {
+  source              = "../../modules/fabric-net-svpc-access"
+  host_project_id     = "${module.net-vpc-shared.svpc_host_project_id}"
+  service_project_num = 1
+  service_project_ids = ["${var.service_project_id_full}"]
+  host_subnets        = ["${module.net-vpc-shared.subnets_names}"]
+  host_subnet_regions = ["${module.net-vpc-shared.subnets_regions}"]
+
+  host_subnet_users = {
+    first  = "${local.first_gce_sa},${local.second_gce_sa}"
+    second = "${local.second_gce_sa}"
+  }
+}

--- a/examples/submodule_svpc_access/main.tf
+++ b/examples/submodule_svpc_access/main.tf
@@ -48,7 +48,7 @@ module "net-svpc-access" {
   source              = "../../modules/fabric-net-svpc-access"
   host_project_id     = "${module.net-vpc-shared.svpc_host_project_id}"
   service_project_num = 1
-  service_project_ids = ["${var.service_project_id_full}"]
+  service_project_ids = ["${var.service_project_id_full_access}"]
   host_subnets        = ["${module.net-vpc-shared.subnets_names}"]
   host_subnet_regions = ["${module.net-vpc-shared.subnets_regions}"]
 

--- a/examples/submodule_svpc_access/outputs.tf
+++ b/examples/submodule_svpc_access/outputs.tf
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+

--- a/examples/submodule_svpc_access/variables.tf
+++ b/examples/submodule_svpc_access/variables.tf
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "host_project_id" {
+  description = "Id of the host project where the shared VPC will be created."
+}
+
+variable "service_project_id_full_access" {
+  description = "Id of the service project that will get VPC-level access."
+}
+
+variable "service_project_number_first_subnet" {
+  description = "Project number to derive service accounts with access to first subnet."
+}
+
+variable "service_project_number_multi_subnet" {
+  description = "Project number to derive service accounts with access to first and second subnet."
+}
+
+variable "network_name" {
+  description = "Name of the shared VPC."
+  default     = "test-svpc"
+}

--- a/modules/fabric-net-svpc-access/README.md
+++ b/modules/fabric-net-svpc-access/README.md
@@ -1,0 +1,53 @@
+# Google Cloud Shared VPC Access Configuration
+
+This module allows configuring service project access to a Shared VPC, created with the top-level network module. Two configuration modes for each service project are supported:
+
+- VPC access, where service projects are granted IAM roles at the host project level, and can use any of the VPC subnets
+- subnetwork access, where service projects are granted IAM roles at the subnet level, and can then only use specific subnets
+
+Full details on service project configuration can be found in the Google Cloud documentation on [provisioning Shared VPC](https://cloud.google.com/vpc/docs/provisioning-shared-vpc), and on [setting up clusters with Shared VPC](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-shared-vpc).
+
+The resources created/managed by this module are:
+
+- one `google_compute_shared_vpc_service_project` resource for each project where full VPC access is needed
+- one `google_compute_subnetwork_iam_binding` for each subnetwork where individual subnetwork access is needed
+
+## Usage
+
+Basic usage of this module is as follows:
+
+```hcl
+module "net-shared-vpc-access" {
+  source              = "terraform-google-modules/terraform-google-network/google//modules/fabric-net-svpc-access"
+  host_project_id     = "my-host-project-id"
+  service_project_num = 1
+  service_project_ids = ["my-service-project-id"]
+  host_subnets        = ["my-subnet-1", "my-subnet-2"]
+  host_subnet_regions = ["europe-west1", "europe-west1]
+  host_subnet_users   = [
+    "serviceAccount:${module.project-foo.gce_service_account}",
+    "serviceAccount:${module.project-spam.gce_service_account},group:spam@example.org"
+  ]
+}
+```
+
+[^]: (autogen_docs_start)
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| host\_project\_id | Project id of the shared VPC host project. | string | n/a | yes |
+| host\_subnet\_regions | List of subnet regions, one per subnet. | list | `<list>` | no |
+| host\_subnet\_users | Map of comma-delimited IAM-style members, one per subnet. | map | `<map>` | no |
+| host\_subnets | List of subnet names on which to grant access. | list | `<list>` | no |
+| service\_project\_ids | Ids of the service projects that will be granted access to all subnetworks. | list | n/a | yes |
+| service\_project\_num | Number of service projects that will be granted access to all subnetworks. | string | `"0"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| service\_projects | Project ids of the services with access to all subnets. |
+
+[^]: (autogen_docs_end)

--- a/modules/fabric-net-svpc-access/main.tf
+++ b/modules/fabric-net-svpc-access/main.tf
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_compute_shared_vpc_service_project" "projects" {
+  count           = "${var.service_project_num}"
+  host_project    = "${var.host_project_id}"
+  service_project = "${element(var.service_project_ids, count.index)}"
+}
+
+resource "google_compute_subnetwork_iam_binding" "subnets" {
+  count      = "${length(var.host_subnets)}"
+  project    = "${var.host_project_id}"
+  region     = "${element(var.host_subnet_regions, count.index)}"
+  subnetwork = "${element(var.host_subnets, count.index)}"
+  role       = "roles/compute.networkUser"
+
+  members = ["${compact(split(",",
+    lookup(var.host_subnet_users, element(var.host_subnets, count.index))
+  ))}"]
+}

--- a/modules/fabric-net-svpc-access/outputs.tf
+++ b/modules/fabric-net-svpc-access/outputs.tf
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "service_projects" {
+  description = "Project ids of the services with access to all subnets."
+  value       = ["${google_compute_shared_vpc_service_project.projects.*.service_project}"]
+}

--- a/modules/fabric-net-svpc-access/variables.tf
+++ b/modules/fabric-net-svpc-access/variables.tf
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "host_project_id" {
+  description = "Project id of the shared VPC host project."
+}
+
+# passed-in values can be dynamic, so variables used in count need to be separate
+
+variable "service_project_num" {
+  description = "Number of service projects that will be granted access to all subnetworks."
+  default     = 0
+}
+
+variable "service_project_ids" {
+  description = "Ids of the service projects that will be granted access to all subnetworks."
+  type        = "list"
+}
+
+variable "host_subnets" {
+  description = "List of subnet names on which to grant access."
+  default     = []
+}
+
+variable "host_subnet_regions" {
+  description = "List of subnet regions, one per subnet."
+  default     = []
+}
+
+variable "host_subnet_users" {
+  description = "Map of comma-delimited IAM-style members, one per subnet."
+  default     = {}
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,6 +24,11 @@ output "network_self_link" {
   description = "The URI of the VPC being created"
 }
 
+output "svpc_host_project_id" {
+  value       = "${element(concat(google_compute_shared_vpc_host_project.shared_vpc_host.*.project, list("")), 0)}"
+  description = "Shared VPC host project id."
+}
+
 output "subnets_names" {
   value       = "${google_compute_subnetwork.subnetwork.*.name}"
   description = "The names of the subnets being created"


### PR DESCRIPTION
As per the discussion in #42 this adds a simple submodule to configure Shared VPC network attachments, and the corresponding examples.

The module allows configuring VPC-level access through the `google_compute_shared_vpc_service_project` resource for 0-n projects, or subnet-level access for IAM-style members through the `google_compute_subnetwork_iam_binding` resource.

As discussed, there's a new output in the top-level module to expose the Shared VPC project id, which is used to trigger the inter-module dependency. Contrary to what I expected it seems to work, but even if it didn't it would not cause any major issue, as once SVPC has been turned on and applied, the submodule would work (meaning at most two consecutive apply runs).

There are no tests, as they would need extra service projects defined in the infrastructure used for the CI runs. I tested locally of course, and it works.