### PR TITLE
Fix terraform validate error

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ resource "null_resource" "delete_default_internet_gateway_routes" {
     command = "${path.module}/scripts/delete-default-gateway-routes.sh ${var.project_id} ${var.network_name}"
   }
 
-  triggers {
+  triggers = {
     number_of_routes = "${length(var.routes)}"
   }
 


### PR DESCRIPTION
Without this patch, terraform validate with 0.12 is failing with the
following error message:

    Error: Unsupported block type

      on .terraform/modules/vpc/terraform-google-modules-terraform-google-network-d1b6646/main.tf line 94, in resource "null_resource" "delete_default_internet_gateway_routes":
      94:   triggers {

    Blocks of type "triggers" are not expected here. Did you mean to define
    argument "triggers"? If so, use the equals sign to assign it a value.

Note, this error also occurs when validating modules which depend on the
network module.  For example, this error has been copied from running
`make check_terraform` inside the project-factory module.