### PR TITLE
Add a note about 0.11.x compatible version to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ It supports creating:
 - Subnets within the VPC
 - Secondary ranges for the subnets (if applicable)
 
+## Compatibility
+
+This module is meant for use with Terraform 0.12. If you haven't [upgraded](https://www.terraform.io/upgrade-guides/0-12.html) and need a Terraform 0.11.x-compatible version of this module, the last released version intended for Terraform 0.11.x is [0.8.0](https://registry.terraform.io/modules/terraform-google-modules/network/google/0.8.0).
+
 ## Usage
 You can go to the examples folder, however the usage of the module could be like this in your own main.tf file:
 


### PR DESCRIPTION
Per https://github.com/terraform-google-modules/terraform-google-network/pull/47#discussion_r300796223

We should probably add a note like this to each module's 0.12 upgrade PR.