### PR TITLE
feat: adding optional description field to created subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,10 @@ The subnets list contains maps, where each object represents a subnet. Each map 
 | subnet_region         | The region where the subnet will be created                      | string |    -    |    yes   |
 | subnet_private_access | Whether this subnet will have private Google access enabled      | string |  false  |    no    |
 | subnet_flow_logs      | Whether the subnet will record and send flow log data to logging | string |  false  |    no    |
-| description           | The description of the subnet being created                      | string |   null  |    no    |
 
 ### Route Inputs
 
-The routes list contains maps, where each object represents a route. For the next_hop** inputs, only one is possible to be used in each route. Having two next_hop** inputs will produce an error. Each map has the following inputs (please see examples folder for additional references):
+The routes list contains maps, where each object represents a route. For the next_hop__ inputs, only one is possible to be used in each route. Having two next_hop__ inputs will produce an error. Each map has the following inputs (please see examples folder for additional references):
 
 | Name                   | Description                                                                                                                                                                                                                                      |  Type  | Default | Required |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :----: | :-----: | :------: |

--- a/README.md
+++ b/README.md
@@ -4,16 +4,15 @@ This modules makes it easy to set up a new VPC Network in GCP by defining your n
 
 It supports creating:
 
--   A Google Virtual Private Network (VPC)
--   Subnets within the VPC
--   Secondary ranges for the subnets (if applicable)
+- A Google Virtual Private Network (VPC)
+- Subnets within the VPC
+- Secondary ranges for the subnets (if applicable)
 
 ## Compatibility
 
 This module is meant for use with Terraform 0.12. If you haven't [upgraded](https://www.terraform.io/upgrade-guides/0-12.html) and need a Terraform 0.11.x-compatible version of this module, the last released version intended for Terraform 0.11.x is [0.8.0](https://registry.terraform.io/modules/terraform-google-modules/network/google/0.8.0).
 
 ## Usage
-
 You can go to the examples folder, however the usage of the module could be like this in your own main.tf file:
 
 ```hcl
@@ -74,96 +73,90 @@ module "vpc" {
 
 Then perform the following commands on the root folder:
 
--   `terraform init` to get the plugins
--   `terraform plan` to see the infrastructure plan
--   `terraform apply` to apply the infrastructure build
--   `terraform destroy` to destroy the built infrastructure
+- `terraform init` to get the plugins
+- `terraform plan` to see the infrastructure plan
+- `terraform apply` to apply the infrastructure build
+- `terraform destroy` to destroy the built infrastructure
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-
 ## Inputs
 
-| Name                                   | Description                                                                                                                                                                                                                                                                                |        Type       |   Default  | Required |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :---------------: | :--------: | :------: |
-| auto_create_subnetworks                | When set to true, the network is created in 'auto subnet mode' and it will create a subnet for each region automatically across the 10.128.0.0/9 address range. When set to false, the network is created in 'custom subnet mode' so the user can explicitly connect subnetwork resources. |        bool       |  `"false"` |    no    |
-| delete_default_internet_gateway_routes | If set, ensure that all routes within the network specified whose names begin with 'default-route' and with a next hop of 'default-internet-gateway' are deleted                                                                                                                           |       string      |  `"false"` |    no    |
-| description                            | An optional description of this resource. The resource must be recreated to modify this field.                                                                                                                                                                                             |       string      |    `""`    |    no    |
-| network_name                           | The name of the network being created                                                                                                                                                                                                                                                      |       string      |     n/a    |    yes   |
-| project_id                             | The ID of the project where this VPC will be created                                                                                                                                                                                                                                       |       string      |     n/a    |    yes   |
-| routes                                 | List of routes being created in this VPC                                                                                                                                                                                                                                                   | list(map(string)) |  `<list>`  |    no    |
-| routing_mode                           | The network routing mode (default 'GLOBAL')                                                                                                                                                                                                                                                |       string      | `"GLOBAL"` |    no    |
-| secondary_ranges                       | Secondary ranges that will be used in some of the subnets                                                                                                                                                                                                                                  |       object      |     n/a    |    yes   |
-| shared_vpc_host                        | Makes this project a Shared VPC host if 'true' (default 'false')                                                                                                                                                                                                                           |       string      |  `"false"` |    no    |
-| subnets                                | The list of subnets being created                                                                                                                                                                                                                                                          | list(map(string)) |     n/a    |    yes   |
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| auto\_create\_subnetworks | When set to true, the network is created in 'auto subnet mode' and it will create a subnet for each region automatically across the 10.128.0.0/9 address range. When set to false, the network is created in 'custom subnet mode' so the user can explicitly connect subnetwork resources. | bool | `"false"` | no |
+| delete\_default\_internet\_gateway\_routes | If set, ensure that all routes within the network specified whose names begin with 'default-route' and with a next hop of 'default-internet-gateway' are deleted | string | `"false"` | no |
+| description | An optional description of this resource. The resource must be recreated to modify this field. | string | `""` | no |
+| network\_name | The name of the network being created | string | n/a | yes |
+| project\_id | The ID of the project where this VPC will be created | string | n/a | yes |
+| routes | List of routes being created in this VPC | list(map(string)) | `<list>` | no |
+| routing\_mode | The network routing mode (default 'GLOBAL') | string | `"GLOBAL"` | no |
+| secondary\_ranges | Secondary ranges that will be used in some of the subnets | object | n/a | yes |
+| shared\_vpc\_host | Makes this project a Shared VPC host if 'true' (default 'false') | string | `"false"` | no |
+| subnets | The list of subnets being created | list(map(string)) | n/a | yes |
 
 ## Outputs
 
-| Name                     | Description                                                              |
-| ------------------------ | ------------------------------------------------------------------------ |
-| network_name             | The name of the VPC being created                                        |
-| network_self_link        | The URI of the VPC being created                                         |
-| routes                   | The routes associated with this VPC                                      |
-| subnets_flow_logs        | Whether the subnets will have VPC flow logs enabled                      |
-| subnets_ips              | The IPs and CIDRs of the subnets being created                           |
-| subnets_names            | The names of the subnets being created                                   |
-| subnets_private_access   | Whether the subnets will have access to Google API's without a public IP |
-| subnets_regions          | The region where the subnets will be created                             |
-| subnets_secondary_ranges | The secondary ranges associated with these subnets                       |
-| subnets_self_links       | The self-links of subnets being created                                  |
-| svpc_host_project_id     | Shared VPC host project id.                                              |
+| Name | Description |
+|------|-------------|
+| network\_name | The name of the VPC being created |
+| network\_self\_link | The URI of the VPC being created |
+| routes | The routes associated with this VPC |
+| subnets\_flow\_logs | Whether the subnets will have VPC flow logs enabled |
+| subnets\_ips | The IPs and CIDRs of the subnets being created |
+| subnets\_names | The names of the subnets being created |
+| subnets\_private\_access | Whether the subnets will have access to Google API's without a public IP |
+| subnets\_regions | The region where the subnets will be created |
+| subnets\_secondary\_ranges | The secondary ranges associated with these subnets |
+| subnets\_self\_links | The self-links of subnets being created |
+| svpc\_host\_project\_id | Shared VPC host project id. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ### Subnet Inputs
-
 The subnets list contains maps, where each object represents a subnet. Each map has the following inputs (please see examples folder for additional references):
 
-| Name                  | Description                                                      |  Type  | Default | Required |
-| --------------------- | ---------------------------------------------------------------- | :----: | :-----: | :------: |
-| subnet_name           | The name of the subnet being created                             | string |    -    |    yes   |
-| subnet_ip             | The IP and CIDR range of the subnet being created                | string |    -    |    yes   |
-| subnet_region         | The region where the subnet will be created                      | string |    -    |    yes   |
-| subnet_private_access | Whether this subnet will have private Google access enabled      | string |  false  |    no    |
-| subnet_flow_logs      | Whether the subnet will record and send flow log data to logging | string |  false  |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| subnet_name | The name of the subnet being created  | string | - | yes |
+| subnet_ip | The IP and CIDR range of the subnet being created | string | - | yes |
+| subnet_region | The region where the subnet will be created  | string | - | yes |
+| subnet_private_access | Whether this subnet will have private Google access enabled | string | false | no |
+| subnet_flow_logs  | Whether the subnet will record and send flow log data to logging | string | false | no |
+| description | The description of the subnet being created | string | null | no |
 
 ### Route Inputs
+The routes list contains maps, where each object represents a route. For the next_hop_* inputs, only one is possible to be used in each route. Having two next_hop_* inputs will produce an error. Each map has the following inputs (please see examples folder for additional references):
 
-The routes list contains maps, where each object represents a route. For the next_hop__ inputs, only one is possible to be used in each route. Having two next_hop__ inputs will produce an error. Each map has the following inputs (please see examples folder for additional references):
-
-| Name                   | Description                                                                                                                                                                                                                                      |  Type  | Default | Required |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :----: | :-----: | :------: |
-| name                   | The name of the route being created                                                                                                                                                                                                              | string |    -    |    no    |
-| description            | The description of the route being created                                                                                                                                                                                                       | string |    -    |    no    |
-| tags                   | The network tags assigned to this route. This is a list in string format. Eg. "tag-01,tag-02"                                                                                                                                                    | string |    -    |    yes   |
-| destination_range      | The destination range of outgoing packets that this route applies to. Only IPv4 is supported                                                                                                                                                     | string |    -    |    yes   |
-| next_hop_internet      | Whether the next hop to this route will the default internet gateway. Use "true" to enable this as next hop                                                                                                                                      | string |    -    |    yes   |
-| next_hop_ip            | Network IP address of an instance that should handle matching packets                                                                                                                                                                            | string |    -    |    yes   |
-| next_hop_instance      | URL or name of an instance that should handle matching packets. If just name is specified "next_hop_instance_zone" is required                                                                                                                   | string |    -    |    yes   |
-| next_hop_instance_zone | The zone of the instance specified in next_hop_instance. Only required if next_hop_instance is specified as a name                                                                                                                               | string |    -    |    no    |
-| next_hop_vpn_tunnel    | URL to a VpnTunnel that should handle matching packets                                                                                                                                                                                           | string |    -    |    yes   |
-| priority               | The priority of this route. Priority is used to break ties in cases where there is more than one matching route of equal prefix length. In the case of two routes with equal prefix length, the one with the lowest-numbered priority value wins | string |   1000  |    yes   |
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| name | The name of the route being created  | string | - | no |
+| description | The description of the route being created | string | - | no |
+| tags | The network tags assigned to this route. This is a list in string format. Eg. "tag-01,tag-02"| string | - | yes |
+| destination_range | The destination range of outgoing packets that this route applies to. Only IPv4 is supported | string | - | yes
+| next_hop_internet | Whether the next hop to this route will the default internet gateway. Use "true" to enable this as next hop | string | - | yes |
+| next_hop_ip | Network IP address of an instance that should handle matching packets | string | - | yes |
+| next_hop_instance |  URL or name of an instance that should handle matching packets. If just name is specified "next_hop_instance_zone" is required | string | - | yes |
+| next_hop_instance_zone |  The zone of the instance specified in next_hop_instance. Only required if next_hop_instance is specified as a name | string | - | no |
+| next_hop_vpn_tunnel | URL to a VpnTunnel that should handle matching packets | string | - | yes |
+| priority | The priority of this route. Priority is used to break ties in cases where there is more than one matching route of equal prefix length. In the case of two routes with equal prefix length, the one with the lowest-numbered priority value wins | string | 1000 | yes |
 
 ## Requirements
-
 ### Installed Software
-
--   [Terraform](https://www.terraform.io/downloads.html) ~> 0.12.0
--   [Terraform Provider for GCP][terraform-provider-google] ~> 2.10.0
--   [gcloud](https://cloud.google.com/sdk/gcloud/) >243.0.0
+- [Terraform](https://www.terraform.io/downloads.html) ~> 0.12.0
+- [Terraform Provider for GCP][terraform-provider-google] ~> 2.10.0
+- [gcloud](https://cloud.google.com/sdk/gcloud/) >243.0.0
 
 ### Configure a Service Account
-
 In order to execute this module you must have a Service Account with the following roles:
 
--   roles/compute.networkAdmin on the organization or folder
+- roles/compute.networkAdmin on the organization or folder
 
 If you are going to manage a Shared VPC, you must have either:
 
--   roles/compute.xpnAdmin on the organization
--   roles/compute.xpnAdmin on the folder (beta)
+- roles/compute.xpnAdmin on the organization
+- roles/compute.xpnAdmin on the folder (beta)
 
 ### Enable API's
-
 In order to operate with the Service Account you must activate the following API on the project where the Service Account was created:
 
--   Compute Engine API - compute.googleapis.com
+- Compute Engine API - compute.googleapis.com

--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@ This modules makes it easy to set up a new VPC Network in GCP by defining your n
 
 It supports creating:
 
-- A Google Virtual Private Network (VPC)
-- Subnets within the VPC
-- Secondary ranges for the subnets (if applicable)
+-   A Google Virtual Private Network (VPC)
+-   Subnets within the VPC
+-   Secondary ranges for the subnets (if applicable)
 
 ## Compatibility
 
 This module is meant for use with Terraform 0.12. If you haven't [upgraded](https://www.terraform.io/upgrade-guides/0-12.html) and need a Terraform 0.11.x-compatible version of this module, the last released version intended for Terraform 0.11.x is [0.8.0](https://registry.terraform.io/modules/terraform-google-modules/network/google/0.8.0).
 
 ## Usage
+
 You can go to the examples folder, however the usage of the module could be like this in your own main.tf file:
 
 ```hcl
@@ -36,6 +37,7 @@ module "vpc" {
             subnet_region         = "us-west1"
             subnet_private_access = "true"
             subnet_flow_logs      = "true"
+            description           = "This subnet has a description"
         },
     ]
 
@@ -72,89 +74,96 @@ module "vpc" {
 
 Then perform the following commands on the root folder:
 
-- `terraform init` to get the plugins
-- `terraform plan` to see the infrastructure plan
-- `terraform apply` to apply the infrastructure build
-- `terraform destroy` to destroy the built infrastructure
+-   `terraform init` to get the plugins
+-   `terraform plan` to see the infrastructure plan
+-   `terraform apply` to apply the infrastructure build
+-   `terraform destroy` to destroy the built infrastructure
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| auto\_create\_subnetworks | When set to true, the network is created in 'auto subnet mode' and it will create a subnet for each region automatically across the 10.128.0.0/9 address range. When set to false, the network is created in 'custom subnet mode' so the user can explicitly connect subnetwork resources. | bool | `"false"` | no |
-| delete\_default\_internet\_gateway\_routes | If set, ensure that all routes within the network specified whose names begin with 'default-route' and with a next hop of 'default-internet-gateway' are deleted | string | `"false"` | no |
-| description | An optional description of this resource. The resource must be recreated to modify this field. | string | `""` | no |
-| network\_name | The name of the network being created | string | n/a | yes |
-| project\_id | The ID of the project where this VPC will be created | string | n/a | yes |
-| routes | List of routes being created in this VPC | list(map(string)) | `<list>` | no |
-| routing\_mode | The network routing mode (default 'GLOBAL') | string | `"GLOBAL"` | no |
-| secondary\_ranges | Secondary ranges that will be used in some of the subnets | object | n/a | yes |
-| shared\_vpc\_host | Makes this project a Shared VPC host if 'true' (default 'false') | string | `"false"` | no |
-| subnets | The list of subnets being created | list(map(string)) | n/a | yes |
+| Name                                   | Description                                                                                                                                                                                                                                                                                |        Type       |   Default  | Required |
+| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :---------------: | :--------: | :------: |
+| auto_create_subnetworks                | When set to true, the network is created in 'auto subnet mode' and it will create a subnet for each region automatically across the 10.128.0.0/9 address range. When set to false, the network is created in 'custom subnet mode' so the user can explicitly connect subnetwork resources. |        bool       |  `"false"` |    no    |
+| delete_default_internet_gateway_routes | If set, ensure that all routes within the network specified whose names begin with 'default-route' and with a next hop of 'default-internet-gateway' are deleted                                                                                                                           |       string      |  `"false"` |    no    |
+| description                            | An optional description of this resource. The resource must be recreated to modify this field.                                                                                                                                                                                             |       string      |    `""`    |    no    |
+| network_name                           | The name of the network being created                                                                                                                                                                                                                                                      |       string      |     n/a    |    yes   |
+| project_id                             | The ID of the project where this VPC will be created                                                                                                                                                                                                                                       |       string      |     n/a    |    yes   |
+| routes                                 | List of routes being created in this VPC                                                                                                                                                                                                                                                   | list(map(string)) |  `<list>`  |    no    |
+| routing_mode                           | The network routing mode (default 'GLOBAL')                                                                                                                                                                                                                                                |       string      | `"GLOBAL"` |    no    |
+| secondary_ranges                       | Secondary ranges that will be used in some of the subnets                                                                                                                                                                                                                                  |       object      |     n/a    |    yes   |
+| shared_vpc_host                        | Makes this project a Shared VPC host if 'true' (default 'false')                                                                                                                                                                                                                           |       string      |  `"false"` |    no    |
+| subnets                                | The list of subnets being created                                                                                                                                                                                                                                                          | list(map(string)) |     n/a    |    yes   |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| network\_name | The name of the VPC being created |
-| network\_self\_link | The URI of the VPC being created |
-| routes | The routes associated with this VPC |
-| subnets\_flow\_logs | Whether the subnets will have VPC flow logs enabled |
-| subnets\_ips | The IPs and CIDRs of the subnets being created |
-| subnets\_names | The names of the subnets being created |
-| subnets\_private\_access | Whether the subnets will have access to Google API's without a public IP |
-| subnets\_regions | The region where the subnets will be created |
-| subnets\_secondary\_ranges | The secondary ranges associated with these subnets |
-| subnets\_self\_links | The self-links of subnets being created |
-| svpc\_host\_project\_id | Shared VPC host project id. |
+| Name                     | Description                                                              |
+| ------------------------ | ------------------------------------------------------------------------ |
+| network_name             | The name of the VPC being created                                        |
+| network_self_link        | The URI of the VPC being created                                         |
+| routes                   | The routes associated with this VPC                                      |
+| subnets_flow_logs        | Whether the subnets will have VPC flow logs enabled                      |
+| subnets_ips              | The IPs and CIDRs of the subnets being created                           |
+| subnets_names            | The names of the subnets being created                                   |
+| subnets_private_access   | Whether the subnets will have access to Google API's without a public IP |
+| subnets_regions          | The region where the subnets will be created                             |
+| subnets_secondary_ranges | The secondary ranges associated with these subnets                       |
+| subnets_self_links       | The self-links of subnets being created                                  |
+| svpc_host_project_id     | Shared VPC host project id.                                              |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ### Subnet Inputs
+
 The subnets list contains maps, where each object represents a subnet. Each map has the following inputs (please see examples folder for additional references):
 
-| Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| subnet_name | The name of the subnet being created  | string | - | yes |
-| subnet_ip | The IP and CIDR range of the subnet being created | string | - | yes |
-| subnet_region | The region where the subnet will be created  | string | - | yes |
-| subnet_private_access | Whether this subnet will have private Google access enabled | string | false | no |
-| subnet_flow_logs  | Whether the subnet will record and send flow log data to logging | string | false | no |
+| Name                  | Description                                                      |  Type  | Default | Required |
+| --------------------- | ---------------------------------------------------------------- | :----: | :-----: | :------: |
+| subnet_name           | The name of the subnet being created                             | string |    -    |    yes   |
+| subnet_ip             | The IP and CIDR range of the subnet being created                | string |    -    |    yes   |
+| subnet_region         | The region where the subnet will be created                      | string |    -    |    yes   |
+| subnet_private_access | Whether this subnet will have private Google access enabled      | string |  false  |    no    |
+| subnet_flow_logs      | Whether the subnet will record and send flow log data to logging | string |  false  |    no    |
 
 ### Route Inputs
-The routes list contains maps, where each object represents a route. For the next_hop_* inputs, only one is possible to be used in each route. Having two next_hop_* inputs will produce an error. Each map has the following inputs (please see examples folder for additional references):
 
-| Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| name | The name of the route being created  | string | - | no |
-| description | The description of the route being created | string | - | no |
-| tags | The network tags assigned to this route. This is a list in string format. Eg. "tag-01,tag-02"| string | - | yes |
-| destination_range | The destination range of outgoing packets that this route applies to. Only IPv4 is supported | string | - | yes
-| next_hop_internet | Whether the next hop to this route will the default internet gateway. Use "true" to enable this as next hop | string | - | yes |
-| next_hop_ip | Network IP address of an instance that should handle matching packets | string | - | yes |
-| next_hop_instance |  URL or name of an instance that should handle matching packets. If just name is specified "next_hop_instance_zone" is required | string | - | yes |
-| next_hop_instance_zone |  The zone of the instance specified in next_hop_instance. Only required if next_hop_instance is specified as a name | string | - | no |
-| next_hop_vpn_tunnel | URL to a VpnTunnel that should handle matching packets | string | - | yes |
-| priority | The priority of this route. Priority is used to break ties in cases where there is more than one matching route of equal prefix length. In the case of two routes with equal prefix length, the one with the lowest-numbered priority value wins | string | 1000 | yes |
+The routes list contains maps, where each object represents a route. For the next_hop__ inputs, only one is possible to be used in each route. Having two next_hop__ inputs will produce an error. Each map has the following inputs (please see examples folder for additional references):
+
+| Name                   | Description                                                                                                                                                                                                                                      |  Type  | Default | Required |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :----: | :-----: | :------: |
+| name                   | The name of the route being created                                                                                                                                                                                                              | string |    -    |    no    |
+| description            | The description of the route being created                                                                                                                                                                                                       | string |    -    |    no    |
+| tags                   | The network tags assigned to this route. This is a list in string format. Eg. "tag-01,tag-02"                                                                                                                                                    | string |    -    |    yes   |
+| destination_range      | The destination range of outgoing packets that this route applies to. Only IPv4 is supported                                                                                                                                                     | string |    -    |    yes   |
+| next_hop_internet      | Whether the next hop to this route will the default internet gateway. Use "true" to enable this as next hop                                                                                                                                      | string |    -    |    yes   |
+| next_hop_ip            | Network IP address of an instance that should handle matching packets                                                                                                                                                                            | string |    -    |    yes   |
+| next_hop_instance      | URL or name of an instance that should handle matching packets. If just name is specified "next_hop_instance_zone" is required                                                                                                                   | string |    -    |    yes   |
+| next_hop_instance_zone | The zone of the instance specified in next_hop_instance. Only required if next_hop_instance is specified as a name                                                                                                                               | string |    -    |    no    |
+| next_hop_vpn_tunnel    | URL to a VpnTunnel that should handle matching packets                                                                                                                                                                                           | string |    -    |    yes   |
+| priority               | The priority of this route. Priority is used to break ties in cases where there is more than one matching route of equal prefix length. In the case of two routes with equal prefix length, the one with the lowest-numbered priority value wins | string |   1000  |    yes   |
 
 ## Requirements
+
 ### Installed Software
-- [Terraform](https://www.terraform.io/downloads.html) ~> 0.12.0
-- [Terraform Provider for GCP][terraform-provider-google] ~> 2.10.0
-- [gcloud](https://cloud.google.com/sdk/gcloud/) >243.0.0
+
+-   [Terraform](https://www.terraform.io/downloads.html) ~> 0.12.0
+-   [Terraform Provider for GCP][terraform-provider-google] ~> 2.10.0
+-   [gcloud](https://cloud.google.com/sdk/gcloud/) >243.0.0
 
 ### Configure a Service Account
+
 In order to execute this module you must have a Service Account with the following roles:
 
-- roles/compute.networkAdmin on the organization or folder
+-   roles/compute.networkAdmin on the organization or folder
 
 If you are going to manage a Shared VPC, you must have either:
 
-- roles/compute.xpnAdmin on the organization
-- roles/compute.xpnAdmin on the folder (beta)
+-   roles/compute.xpnAdmin on the organization
+-   roles/compute.xpnAdmin on the folder (beta)
 
 ### Enable API's
+
 In order to operate with the Service Account you must activate the following API on the project where the Service Account was created:
 
-- Compute Engine API - compute.googleapis.com
+-   Compute Engine API - compute.googleapis.com

--- a/README.md
+++ b/README.md
@@ -125,10 +125,11 @@ The subnets list contains maps, where each object represents a subnet. Each map 
 | subnet_region         | The region where the subnet will be created                      | string |    -    |    yes   |
 | subnet_private_access | Whether this subnet will have private Google access enabled      | string |  false  |    no    |
 | subnet_flow_logs      | Whether the subnet will record and send flow log data to logging | string |  false  |    no    |
+| description           | The description of the subnet being created                      | string |   null  |    no    |
 
 ### Route Inputs
 
-The routes list contains maps, where each object represents a route. For the next_hop__ inputs, only one is possible to be used in each route. Having two next_hop__ inputs will produce an error. Each map has the following inputs (please see examples folder for additional references):
+The routes list contains maps, where each object represents a route. For the next_hop** inputs, only one is possible to be used in each route. Having two next_hop** inputs will produce an error. Each map has the following inputs (please see examples folder for additional references):
 
 | Name                   | Description                                                                                                                                                                                                                                      |  Type  | Default | Required |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :----: | :-----: | :------: |

--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,7 @@ resource "google_compute_subnetwork" "subnetwork" {
   network                  = google_compute_network.network.name
   project                  = var.project_id
   secondary_ip_range       = var.secondary_ranges[lookup(var.subnets[count.index], "subnet_name", null)]
+  description              = lookup(var.subnets[count.index], "description", null)
 }
 
 data "google_compute_subnetwork" "created_subnets" {
@@ -98,4 +99,3 @@ resource "null_resource" "delete_default_internet_gateway_routes" {
     google_compute_route.route,
   ]
 }
-


### PR DESCRIPTION
This allows subnets to optionally be created with a description.

For example:

```
    subnets = [
        {
            subnet_name           = "subnet-01"
            subnet_ip             = "10.10.10.0/24"
            subnet_region         = "us-west1"
        },
        {
            subnet_name           = "subnet-02"
            subnet_ip             = "10.10.20.0/24"
            subnet_region         = "us-west1"
            subnet_private_access = "true"
            subnet_flow_logs      = "true"
            description           = "This subnet has a description"
        },
```