### PR TITLE
Moving secondary_ranges to a key under subnets. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning][semver-site].
 
 ### Fixed
 
-- Made setting `secondary_ranges` optional. [#16] 
+- Made setting `secondary_ranges` optional. [#16]
 
 ## [1.1.0] - 2019-07-24
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ module "vpc" {
             subnet_name           = "subnet-01"
             subnet_ip             = "10.10.10.0/24"
             subnet_region         = "us-west1"
+            subnet_private_access = "false"
+            subnet_flow_logs      = "false"
             secondary_ranges      = [
             	{
                 	range_name    = "subnet-01-secondary-01"
@@ -116,8 +118,8 @@ The subnets list contains maps, where each object represents a subnet. Each map 
 | subnet_ip | The IP and CIDR range of the subnet being created | string | - | yes |
 | subnet_region | The region where the subnet will be created  | string | - | yes |
 | secondary_ranges | Secondary ranges that will be used in some of the subnets | object | `<list>` | yes |
-| subnet_private_access | Whether this subnet will have private Google access enabled | string | false | no |
-| subnet_flow_logs  | Whether the subnet will record and send flow log data to logging | string | false | no |
+| subnet_private_access | Whether this subnet will have private Google access enabled | string | - | yes |
+| subnet_flow_logs  | Whether the subnet will record and send flow log data to logging | string | - | yes |
 | description | The description of the subnet being created | string | null | no |
 
 ### Route Inputs

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ module "vpc" {
             subnet_name           = "subnet-01"
             subnet_ip             = "10.10.10.0/24"
             subnet_region         = "us-west1"
+            secondary_ranges      = [
+            	{
+                	range_name    = "subnet-01-secondary-01"
+                	ip_cidr_range = "192.168.64.0/24"
+            	},
+            ]
         },
         {
             subnet_name           = "subnet-02"
@@ -37,19 +43,9 @@ module "vpc" {
             subnet_private_access = "true"
             subnet_flow_logs      = "true"
             description           = "This subnet has a description"
+            secondary_ranges      = []
         },
     ]
-
-    secondary_ranges = {
-        subnet-01 = [
-            {
-                range_name    = "subnet-01-secondary-01"
-                ip_cidr_range = "192.168.64.0/24"
-            },
-        ]
-
-        subnet-02 = []
-    }
 
     routes = [
         {
@@ -90,9 +86,8 @@ Then perform the following commands on the root folder:
 | project\_id | The ID of the project where this VPC will be created | string | n/a | yes |
 | routes | List of routes being created in this VPC | list(map(string)) | `<list>` | no |
 | routing\_mode | The network routing mode (default 'GLOBAL') | string | `"GLOBAL"` | no |
-| secondary\_ranges | Secondary ranges that will be used in some of the subnets | object | `<map>` | no |
 | shared\_vpc\_host | Makes this project a Shared VPC host if 'true' (default 'false') | string | `"false"` | no |
-| subnets | The list of subnets being created | list(map(string)) | n/a | yes |
+| subnets | The list of subnets being created | list(objet() | n/a | yes |
 
 ## Outputs
 
@@ -120,6 +115,7 @@ The subnets list contains maps, where each object represents a subnet. Each map 
 | subnet_name | The name of the subnet being created  | string | - | yes |
 | subnet_ip | The IP and CIDR range of the subnet being created | string | - | yes |
 | subnet_region | The region where the subnet will be created  | string | - | yes |
+| secondary_ranges | Secondary ranges that will be used in some of the subnets | object | `<list>` | yes |
 | subnet_private_access | Whether this subnet will have private Google access enabled | string | false | no |
 | subnet_flow_logs  | Whether the subnet will record and send flow log data to logging | string | false | no |
 | description | The description of the subnet being created | string | null | no |

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Then perform the following commands on the root folder:
 | routes | List of routes being created in this VPC | list(map(string)) | `<list>` | no |
 | routing\_mode | The network routing mode (default 'GLOBAL') | string | `"GLOBAL"` | no |
 | shared\_vpc\_host | Makes this project a Shared VPC host if 'true' (default 'false') | string | `"false"` | no |
-| subnets | The list of subnets being created | list(objet() | n/a | yes |
+| subnets | The list of subnets being created | object | n/a | yes |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ module "vpc" {
             subnet_region         = "us-west1"
             subnet_private_access = "false"
             subnet_flow_logs      = "false"
+            description           = null
             secondary_ranges      = [
             	{
                 	range_name    = "subnet-01-secondary-01"
@@ -120,7 +121,7 @@ The subnets list contains maps, where each object represents a subnet. Each map 
 | secondary_ranges | Secondary ranges that will be used in some of the subnets | object | `<list>` | yes |
 | subnet_private_access | Whether this subnet will have private Google access enabled | string | - | yes |
 | subnet_flow_logs  | Whether the subnet will record and send flow log data to logging | string | - | yes |
-| description | The description of the subnet being created | string | null | no |
+| description | The description of the subnet being created | string | - | yes |
 
 ### Route Inputs
 The routes list contains maps, where each object represents a route. For the next_hop_* inputs, only one is possible to be used in each route. Having two next_hop_* inputs will produce an error. Each map has the following inputs (please see examples folder for additional references):

--- a/examples/delete_default_gateway_routes/main.tf
+++ b/examples/delete_default_gateway_routes/main.tf
@@ -40,7 +40,7 @@ module "test-vpc-module" {
       secondary_ranges      = []
       subnet_private_access = "false"
       subnet_flow_logs      = "false"
-      description           = ""
+      description           = null
     },
   ]
 }

--- a/examples/delete_default_gateway_routes/main.tf
+++ b/examples/delete_default_gateway_routes/main.tf
@@ -34,9 +34,10 @@ module "test-vpc-module" {
 
   subnets = [
     {
-      subnet_name   = local.subnet_01
-      subnet_ip     = "10.20.30.0/24"
-      subnet_region = "us-west1"
+      subnet_name      = local.subnet_01
+      subnet_ip        = "10.20.30.0/24"
+      subnet_region    = "us-west1"
+      secondary_ranges = []
     },
   ]
 }

--- a/examples/delete_default_gateway_routes/main.tf
+++ b/examples/delete_default_gateway_routes/main.tf
@@ -34,10 +34,12 @@ module "test-vpc-module" {
 
   subnets = [
     {
-      subnet_name      = local.subnet_01
-      subnet_ip        = "10.20.30.0/24"
-      subnet_region    = "us-west1"
-      secondary_ranges = []
+      subnet_name           = local.subnet_01
+      subnet_ip             = "10.20.30.0/24"
+      subnet_region         = "us-west1"
+      secondary_ranges      = []
+      subnet_private_access = "false"
+      subnet_flow_logs      = "false"
     },
   ]
 }

--- a/examples/delete_default_gateway_routes/main.tf
+++ b/examples/delete_default_gateway_routes/main.tf
@@ -40,6 +40,7 @@ module "test-vpc-module" {
       secondary_ranges      = []
       subnet_private_access = "false"
       subnet_flow_logs      = "false"
+      description           = ""
     },
   ]
 }

--- a/examples/multi_vpc/main.tf
+++ b/examples/multi_vpc/main.tf
@@ -69,7 +69,7 @@ module "test-vpc-module-01" {
       subnet_region         = "us-west1"
       subnet_private_access = "false"
       subnet_flow_logs      = "true"
-      description           = ""
+      description           = null
       secondary_ranges = [
         {
           range_name    = "${local.network_01_subnet_01}-01"
@@ -87,7 +87,7 @@ module "test-vpc-module-01" {
       subnet_region         = "us-west1"
       subnet_private_access = "false"
       subnet_flow_logs      = "true"
-      description           = ""
+      description           = null
       secondary_ranges = [
         {
           range_name    = "${local.network_02_subnet_01}-01"
@@ -102,7 +102,7 @@ module "test-vpc-module-01" {
       subnet_private_access = "false"
       subnet_flow_logs      = "true"
       secondary_ranges      = []
-      description           = ""
+      description           = null
     },
   ]
 
@@ -121,7 +121,7 @@ module "test-vpc-module-02" {
       subnet_region         = "us-west1"
       subnet_private_access = "false"
       subnet_flow_logs      = "true"
-      description           = ""
+      description           = null
       secondary_ranges = [
         {
           range_name    = "${local.network_02_subnet_02}-01"
@@ -136,7 +136,7 @@ module "test-vpc-module-02" {
       subnet_private_access = "false"
       subnet_flow_logs      = "true"
       secondary_ranges      = []
-      description           = ""
+      description           = null
     },
   ]
 

--- a/examples/multi_vpc/main.tf
+++ b/examples/multi_vpc/main.tf
@@ -69,6 +69,16 @@ module "test-vpc-module-01" {
       subnet_region         = "us-west1"
       subnet_private_access = "false"
       subnet_flow_logs      = "true"
+      secondary_ranges = [
+        {
+          range_name    = "${local.network_01_subnet_01}-01"
+          ip_cidr_range = "192.168.64.0/24"
+        },
+        {
+          range_name    = "${local.network_01_subnet_01}-02"
+          ip_cidr_range = "192.168.65.0/24"
+        },
+      ]
     },
     {
       subnet_name           = local.network_01_subnet_02
@@ -76,6 +86,12 @@ module "test-vpc-module-01" {
       subnet_region         = "us-west1"
       subnet_private_access = "false"
       subnet_flow_logs      = "true"
+      secondary_ranges = [
+        {
+          range_name    = "${local.network_02_subnet_01}-01"
+          ip_cidr_range = "192.168.74.0/24"
+        },
+      ]
     },
     {
       subnet_name           = local.network_01_subnet_03
@@ -83,28 +99,9 @@ module "test-vpc-module-01" {
       subnet_region         = "us-west1"
       subnet_private_access = "false"
       subnet_flow_logs      = "true"
+      secondary_ranges      = []
     },
   ]
-
-  secondary_ranges = {
-    "${local.network_01_subnet_01}" = [
-      {
-        range_name    = "${local.network_01_subnet_01}-01"
-        ip_cidr_range = "192.168.64.0/24"
-      },
-      {
-        range_name    = "${local.network_01_subnet_01}-02"
-        ip_cidr_range = "192.168.65.0/24"
-      },
-    ]
-
-    "${local.network_01_subnet_02}" = [
-      {
-        range_name    = "${local.network_02_subnet_01}-01"
-        ip_cidr_range = "192.168.74.0/24"
-      },
-    ]
-  }
 
   routes = "${local.network_01_routes}"
 }
@@ -121,6 +118,12 @@ module "test-vpc-module-02" {
       subnet_region         = "us-west1"
       subnet_private_access = "false"
       subnet_flow_logs      = "true"
+      secondary_ranges = [
+        {
+          range_name    = "${local.network_02_subnet_02}-01"
+          ip_cidr_range = "192.168.75.0/24"
+        },
+      ]
     },
     {
       subnet_name           = "${local.network_02_subnet_02}"
@@ -128,17 +131,9 @@ module "test-vpc-module-02" {
       subnet_region         = "us-west1"
       subnet_private_access = "false"
       subnet_flow_logs      = "true"
+      secondary_ranges      = []
     },
   ]
-
-  secondary_ranges = {
-    "${local.network_02_subnet_01}" = [
-      {
-        range_name    = "${local.network_02_subnet_02}-01"
-        ip_cidr_range = "192.168.75.0/24"
-      },
-    ]
-  }
 
   routes = local.network_02_routes
 }

--- a/examples/multi_vpc/main.tf
+++ b/examples/multi_vpc/main.tf
@@ -69,6 +69,7 @@ module "test-vpc-module-01" {
       subnet_region         = "us-west1"
       subnet_private_access = "false"
       subnet_flow_logs      = "true"
+      description           = ""
       secondary_ranges = [
         {
           range_name    = "${local.network_01_subnet_01}-01"
@@ -86,6 +87,7 @@ module "test-vpc-module-01" {
       subnet_region         = "us-west1"
       subnet_private_access = "false"
       subnet_flow_logs      = "true"
+      description           = ""
       secondary_ranges = [
         {
           range_name    = "${local.network_02_subnet_01}-01"
@@ -100,6 +102,7 @@ module "test-vpc-module-01" {
       subnet_private_access = "false"
       subnet_flow_logs      = "true"
       secondary_ranges      = []
+      description           = ""
     },
   ]
 
@@ -118,6 +121,7 @@ module "test-vpc-module-02" {
       subnet_region         = "us-west1"
       subnet_private_access = "false"
       subnet_flow_logs      = "true"
+      description           = ""
       secondary_ranges = [
         {
           range_name    = "${local.network_02_subnet_02}-01"
@@ -132,6 +136,7 @@ module "test-vpc-module-02" {
       subnet_private_access = "false"
       subnet_flow_logs      = "true"
       secondary_ranges      = []
+      description           = ""
     },
   ]
 

--- a/examples/secondary_ranges/main.tf
+++ b/examples/secondary_ranges/main.tf
@@ -41,7 +41,7 @@ module "vpc-secondary-ranges" {
       subnet_region         = "us-west1"
       subnet_private_access = "false"
       subnet_flow_logs      = "false"
-      description           = ""
+      description           = null
       secondary_ranges = [
         {
           range_name    = "${local.subnet_01}-01"
@@ -60,7 +60,7 @@ module "vpc-secondary-ranges" {
       subnet_private_access = "true"
       subnet_flow_logs      = "true"
       secondary_ranges      = []
-      description           = ""
+      description           = null
     },
     {
       subnet_name           = "${local.subnet_03}"
@@ -68,7 +68,7 @@ module "vpc-secondary-ranges" {
       subnet_region         = "us-west1"
       subnet_private_access = "false"
       subnet_flow_logs      = "false"
-      description           = ""
+      description           = null
       secondary_ranges = [
         {
           range_name    = "${local.subnet_03}-01"
@@ -82,7 +82,7 @@ module "vpc-secondary-ranges" {
       subnet_region         = "us-west1"
       subnet_private_access = "false"
       subnet_flow_logs      = "false"
-      description           = ""
+      description           = null
       secondary_ranges      = []
     },
     {
@@ -91,7 +91,7 @@ module "vpc-secondary-ranges" {
       subnet_region         = "us-central1"
       subnet_private_access = "false"
       subnet_flow_logs      = "false"
-      description           = ""
+      description           = null
       secondary_ranges = [
         {
           range_name    = "${local.subnet_01}-01"

--- a/examples/secondary_ranges/main.tf
+++ b/examples/secondary_ranges/main.tf
@@ -85,6 +85,24 @@ module "vpc-secondary-ranges" {
       description           = ""
       secondary_ranges      = []
     },
+    {
+      subnet_name           = "${local.subnet_01}"
+      subnet_ip             = "10.10.50.0/24"
+      subnet_region         = "us-central1"
+      subnet_private_access = "false"
+      subnet_flow_logs      = "false"
+      description           = ""
+      secondary_ranges = [
+        {
+          range_name    = "${local.subnet_01}-01"
+          ip_cidr_range = "192.168.67.0/24"
+        },
+        {
+          range_name    = "${local.subnet_01}-02"
+          ip_cidr_range = "192.168.68.0/24"
+        },
+      ]
+    },
   ]
 
 }

--- a/examples/secondary_ranges/main.tf
+++ b/examples/secondary_ranges/main.tf
@@ -36,9 +36,11 @@ module "vpc-secondary-ranges" {
 
   subnets = [
     {
-      subnet_name   = "${local.subnet_01}"
-      subnet_ip     = "10.10.10.0/24"
-      subnet_region = "us-west1"
+      subnet_name           = "${local.subnet_01}"
+      subnet_ip             = "10.10.10.0/24"
+      subnet_region         = "us-west1"
+      subnet_private_access = "false"
+      subnet_flow_logs      = "false"
       secondary_ranges = [
         {
           range_name    = "${local.subnet_01}-01"
@@ -59,9 +61,11 @@ module "vpc-secondary-ranges" {
       secondary_ranges      = []
     },
     {
-      subnet_name   = "${local.subnet_03}"
-      subnet_ip     = "10.10.30.0/24"
-      subnet_region = "us-west1"
+      subnet_name           = "${local.subnet_03}"
+      subnet_ip             = "10.10.30.0/24"
+      subnet_region         = "us-west1"
+      subnet_private_access = "false"
+      subnet_flow_logs      = "false"
       secondary_ranges = [
         {
           range_name    = "${local.subnet_03}-01"
@@ -70,10 +74,12 @@ module "vpc-secondary-ranges" {
       ]
     },
     {
-      subnet_name      = "${local.subnet_04}"
-      subnet_ip        = "10.10.40.0/24"
-      subnet_region    = "us-west1"
-      secondary_ranges = []
+      subnet_name           = "${local.subnet_04}"
+      subnet_ip             = "10.10.40.0/24"
+      subnet_region         = "us-west1"
+      subnet_private_access = "false"
+      subnet_flow_logs      = "false"
+      secondary_ranges      = []
     },
   ]
 

--- a/examples/secondary_ranges/main.tf
+++ b/examples/secondary_ranges/main.tf
@@ -39,6 +39,16 @@ module "vpc-secondary-ranges" {
       subnet_name   = "${local.subnet_01}"
       subnet_ip     = "10.10.10.0/24"
       subnet_region = "us-west1"
+      secondary_ranges = [
+        {
+          range_name    = "${local.subnet_01}-01"
+          ip_cidr_range = "192.168.64.0/24"
+        },
+        {
+          range_name    = "${local.subnet_01}-02"
+          ip_cidr_range = "192.168.65.0/24"
+        },
+      ]
     },
     {
       subnet_name           = "${local.subnet_02}"
@@ -46,38 +56,25 @@ module "vpc-secondary-ranges" {
       subnet_region         = "us-west1"
       subnet_private_access = "true"
       subnet_flow_logs      = "true"
+      secondary_ranges      = []
     },
     {
       subnet_name   = "${local.subnet_03}"
       subnet_ip     = "10.10.30.0/24"
       subnet_region = "us-west1"
+      secondary_ranges = [
+        {
+          range_name    = "${local.subnet_03}-01"
+          ip_cidr_range = "192.168.66.0/24"
+        },
+      ]
     },
     {
-      subnet_name   = "${local.subnet_04}"
-      subnet_ip     = "10.10.40.0/24"
-      subnet_region = "us-west1"
+      subnet_name      = "${local.subnet_04}"
+      subnet_ip        = "10.10.40.0/24"
+      subnet_region    = "us-west1"
+      secondary_ranges = []
     },
   ]
 
-  secondary_ranges = {
-    "${local.subnet_01}" = [
-      {
-        range_name    = "${local.subnet_01}-01"
-        ip_cidr_range = "192.168.64.0/24"
-      },
-      {
-        range_name    = "${local.subnet_01}-02"
-        ip_cidr_range = "192.168.65.0/24"
-      },
-    ]
-
-    "${local.subnet_02}" = []
-
-    "${local.subnet_03}" = [
-      {
-        range_name    = "${local.subnet_03}-01"
-        ip_cidr_range = "192.168.66.0/24"
-      },
-    ]
-  }
 }

--- a/examples/secondary_ranges/main.tf
+++ b/examples/secondary_ranges/main.tf
@@ -41,6 +41,7 @@ module "vpc-secondary-ranges" {
       subnet_region         = "us-west1"
       subnet_private_access = "false"
       subnet_flow_logs      = "false"
+      description           = ""
       secondary_ranges = [
         {
           range_name    = "${local.subnet_01}-01"
@@ -59,6 +60,7 @@ module "vpc-secondary-ranges" {
       subnet_private_access = "true"
       subnet_flow_logs      = "true"
       secondary_ranges      = []
+      description           = ""
     },
     {
       subnet_name           = "${local.subnet_03}"
@@ -66,6 +68,7 @@ module "vpc-secondary-ranges" {
       subnet_region         = "us-west1"
       subnet_private_access = "false"
       subnet_flow_logs      = "false"
+      description           = ""
       secondary_ranges = [
         {
           range_name    = "${local.subnet_03}-01"
@@ -79,6 +82,7 @@ module "vpc-secondary-ranges" {
       subnet_region         = "us-west1"
       subnet_private_access = "false"
       subnet_flow_logs      = "false"
+      description           = ""
       secondary_ranges      = []
     },
   ]

--- a/examples/simple_project/main.tf
+++ b/examples/simple_project/main.tf
@@ -34,9 +34,10 @@ module "test-vpc-module" {
 
   subnets = [
     {
-      subnet_name   = "${local.subnet_01}"
-      subnet_ip     = "10.10.10.0/24"
-      subnet_region = "us-west1"
+      subnet_name      = "${local.subnet_01}"
+      subnet_ip        = "10.10.10.0/24"
+      subnet_region    = "us-west1"
+      secondary_ranges = []
     },
     {
       subnet_name           = "${local.subnet_02}"
@@ -44,6 +45,7 @@ module "test-vpc-module" {
       subnet_region         = "us-west1"
       subnet_private_access = "true"
       subnet_flow_logs      = "true"
+      secondary_ranges      = []
     },
   ]
 }

--- a/examples/simple_project/main.tf
+++ b/examples/simple_project/main.tf
@@ -40,7 +40,7 @@ module "test-vpc-module" {
       subnet_private_access = "false"
       subnet_flow_logs      = "false"
       secondary_ranges      = []
-      description           = ""
+      description           = null
     },
     {
       subnet_name           = "${local.subnet_02}"

--- a/examples/simple_project/main.tf
+++ b/examples/simple_project/main.tf
@@ -34,10 +34,12 @@ module "test-vpc-module" {
 
   subnets = [
     {
-      subnet_name      = "${local.subnet_01}"
-      subnet_ip        = "10.10.10.0/24"
-      subnet_region    = "us-west1"
-      secondary_ranges = []
+      subnet_name           = "${local.subnet_01}"
+      subnet_ip             = "10.10.10.0/24"
+      subnet_region         = "us-west1"
+      subnet_private_access = "false"
+      subnet_flow_logs      = "false"
+      secondary_ranges      = []
     },
     {
       subnet_name           = "${local.subnet_02}"

--- a/examples/simple_project/main.tf
+++ b/examples/simple_project/main.tf
@@ -40,6 +40,7 @@ module "test-vpc-module" {
       subnet_private_access = "false"
       subnet_flow_logs      = "false"
       secondary_ranges      = []
+      description           = ""
     },
     {
       subnet_name           = "${local.subnet_02}"
@@ -48,6 +49,7 @@ module "test-vpc-module" {
       subnet_private_access = "true"
       subnet_flow_logs      = "true"
       secondary_ranges      = []
+      description           = "This subnet has a description"
     },
   ]
 }

--- a/examples/simple_project_with_regional_network/main.tf
+++ b/examples/simple_project_with_regional_network/main.tf
@@ -41,7 +41,7 @@ module "test-vpc-module" {
       subnet_private_access = "false"
       subnet_flow_logs      = "false"
       secondary_ranges      = []
-      description           = ""
+      description           = null
     },
     {
       subnet_name           = "${local.subnet_02}"
@@ -50,7 +50,7 @@ module "test-vpc-module" {
       subnet_private_access = "true"
       subnet_flow_logs      = "true"
       secondary_ranges      = []
-      description           = ""
+      description           = null
     },
   ]
 }

--- a/examples/simple_project_with_regional_network/main.tf
+++ b/examples/simple_project_with_regional_network/main.tf
@@ -41,6 +41,7 @@ module "test-vpc-module" {
       subnet_private_access = "false"
       subnet_flow_logs      = "false"
       secondary_ranges      = []
+      description           = ""
     },
     {
       subnet_name           = "${local.subnet_02}"
@@ -49,6 +50,7 @@ module "test-vpc-module" {
       subnet_private_access = "true"
       subnet_flow_logs      = "true"
       secondary_ranges      = []
+      description           = ""
     },
   ]
 }

--- a/examples/simple_project_with_regional_network/main.tf
+++ b/examples/simple_project_with_regional_network/main.tf
@@ -35,10 +35,12 @@ module "test-vpc-module" {
 
   subnets = [
     {
-      subnet_name      = "${local.subnet_01}"
-      subnet_ip        = "10.10.10.0/24"
-      subnet_region    = "us-west1"
-      secondary_ranges = []
+      subnet_name           = "${local.subnet_01}"
+      subnet_ip             = "10.10.10.0/24"
+      subnet_region         = "us-west1"
+      subnet_private_access = "false"
+      subnet_flow_logs      = "false"
+      secondary_ranges      = []
     },
     {
       subnet_name           = "${local.subnet_02}"

--- a/examples/simple_project_with_regional_network/main.tf
+++ b/examples/simple_project_with_regional_network/main.tf
@@ -35,9 +35,10 @@ module "test-vpc-module" {
 
   subnets = [
     {
-      subnet_name   = "${local.subnet_01}"
-      subnet_ip     = "10.10.10.0/24"
-      subnet_region = "us-west1"
+      subnet_name      = "${local.subnet_01}"
+      subnet_ip        = "10.10.10.0/24"
+      subnet_region    = "us-west1"
+      secondary_ranges = []
     },
     {
       subnet_name           = "${local.subnet_02}"
@@ -45,6 +46,7 @@ module "test-vpc-module" {
       subnet_region         = "us-west1"
       subnet_private_access = "true"
       subnet_flow_logs      = "true"
+      secondary_ranges      = []
     },
   ]
 }

--- a/examples/submodule_firewall/main.tf
+++ b/examples/submodule_firewall/main.tf
@@ -40,6 +40,7 @@ module "test-vpc-module" {
       subnet_private_access = "false"
       subnet_flow_logs      = "false"
       secondary_ranges      = []
+      description           = ""
     },
     {
       subnet_name           = local.subnet_02
@@ -48,6 +49,7 @@ module "test-vpc-module" {
       subnet_private_access = "true"
       subnet_flow_logs      = "true"
       secondary_ranges      = []
+      description           = ""
     },
   ]
 }

--- a/examples/submodule_firewall/main.tf
+++ b/examples/submodule_firewall/main.tf
@@ -40,7 +40,7 @@ module "test-vpc-module" {
       subnet_private_access = "false"
       subnet_flow_logs      = "false"
       secondary_ranges      = []
-      description           = ""
+      description           = null
     },
     {
       subnet_name           = local.subnet_02
@@ -49,7 +49,7 @@ module "test-vpc-module" {
       subnet_private_access = "true"
       subnet_flow_logs      = "true"
       secondary_ranges      = []
-      description           = ""
+      description           = null
     },
   ]
 }

--- a/examples/submodule_firewall/main.tf
+++ b/examples/submodule_firewall/main.tf
@@ -34,9 +34,10 @@ module "test-vpc-module" {
 
   subnets = [
     {
-      subnet_name   = local.subnet_01
-      subnet_ip     = "10.10.10.0/24"
-      subnet_region = "us-west1"
+      subnet_name      = local.subnet_01
+      subnet_ip        = "10.10.10.0/24"
+      subnet_region    = "us-west1"
+      secondary_ranges = []
     },
     {
       subnet_name           = local.subnet_02
@@ -44,6 +45,7 @@ module "test-vpc-module" {
       subnet_region         = "us-west1"
       subnet_private_access = "true"
       subnet_flow_logs      = "true"
+      secondary_ranges      = []
     },
   ]
 }

--- a/examples/submodule_firewall/main.tf
+++ b/examples/submodule_firewall/main.tf
@@ -34,10 +34,12 @@ module "test-vpc-module" {
 
   subnets = [
     {
-      subnet_name      = local.subnet_01
-      subnet_ip        = "10.10.10.0/24"
-      subnet_region    = "us-west1"
-      secondary_ranges = []
+      subnet_name           = local.subnet_01
+      subnet_ip             = "10.10.10.0/24"
+      subnet_region         = "us-west1"
+      subnet_private_access = "false"
+      subnet_flow_logs      = "false"
+      secondary_ranges      = []
     },
     {
       subnet_name           = local.subnet_02

--- a/examples/submodule_svpc_access/main.tf
+++ b/examples/submodule_svpc_access/main.tf
@@ -27,14 +27,16 @@ module "net-vpc-shared" {
 
   subnets = [
     {
-      subnet_name   = "first"
-      subnet_ip     = "10.10.10.0/24"
-      subnet_region = "europe-west1"
+      subnet_name      = "first"
+      subnet_ip        = "10.10.10.0/24"
+      subnet_region    = "europe-west1"
+      secondary_ranges = []
     },
     {
-      subnet_name   = "second"
-      subnet_ip     = "10.10.20.0/24"
-      subnet_region = "europe-west1"
+      subnet_name      = "second"
+      subnet_ip        = "10.10.20.0/24"
+      subnet_region    = "europe-west1"
+      secondary_ranges = []
     },
   ]
 }

--- a/examples/submodule_svpc_access/main.tf
+++ b/examples/submodule_svpc_access/main.tf
@@ -33,6 +33,7 @@ module "net-vpc-shared" {
       subnet_private_access = "false"
       subnet_flow_logs      = "false"
       secondary_ranges      = []
+      description           = ""
     },
     {
       subnet_name           = "second"
@@ -41,6 +42,7 @@ module "net-vpc-shared" {
       secondary_ranges      = []
       subnet_private_access = "false"
       subnet_flow_logs      = "false"
+      description           = ""
 
     },
   ]

--- a/examples/submodule_svpc_access/main.tf
+++ b/examples/submodule_svpc_access/main.tf
@@ -27,16 +27,21 @@ module "net-vpc-shared" {
 
   subnets = [
     {
-      subnet_name      = "first"
-      subnet_ip        = "10.10.10.0/24"
-      subnet_region    = "europe-west1"
-      secondary_ranges = []
+      subnet_name           = "first"
+      subnet_ip             = "10.10.10.0/24"
+      subnet_region         = "europe-west1"
+      subnet_private_access = "false"
+      subnet_flow_logs      = "false"
+      secondary_ranges      = []
     },
     {
-      subnet_name      = "second"
-      subnet_ip        = "10.10.20.0/24"
-      subnet_region    = "europe-west1"
-      secondary_ranges = []
+      subnet_name           = "second"
+      subnet_ip             = "10.10.20.0/24"
+      subnet_region         = "europe-west1"
+      secondary_ranges      = []
+      subnet_private_access = "false"
+      subnet_flow_logs      = "false"
+
     },
   ]
 }

--- a/examples/submodule_svpc_access/main.tf
+++ b/examples/submodule_svpc_access/main.tf
@@ -33,7 +33,7 @@ module "net-vpc-shared" {
       subnet_private_access = "false"
       subnet_flow_logs      = "false"
       secondary_ranges      = []
-      description           = ""
+      description           = null
     },
     {
       subnet_name           = "second"
@@ -42,7 +42,7 @@ module "net-vpc-shared" {
       secondary_ranges      = []
       subnet_private_access = "false"
       subnet_flow_logs      = "false"
-      description           = ""
+      description           = null
 
     },
   ]

--- a/main.tf
+++ b/main.tf
@@ -43,12 +43,19 @@ resource "google_compute_subnetwork" "subnetwork" {
   name                     = var.subnets[count.index]["subnet_name"]
   ip_cidr_range            = var.subnets[count.index]["subnet_ip"]
   region                   = var.subnets[count.index]["subnet_region"]
-  private_ip_google_access = var.subnets[count.index]["subnet_private_access"]
-  enable_flow_logs         = var.subnets[count.index]["subnet_flow_logs"]
+  private_ip_google_access = lookup(var.subnets[count.index], "subnet_private_access", "false")
+  enable_flow_logs         = lookup(var.subnets[count.index], "subnet_flow_logs", "false")
   network                  = google_compute_network.network.name
   project                  = var.project_id
   description              = lookup(var.subnets[count.index], "description", null)
-  secondary_ip_range       = var.subnets[count.index]["secondary_ranges"]
+  #secondary_ip_range       = var.subnets[count.index]["secondary_ranges"]
+  dynamic "secondary_ip_range" {
+    for_each = var.subnets[count.index]["secondary_ranges"]
+    content {
+      range_name    = secondary_ip_range.value["range_name"] #"tf-test-secondary-range-update1"
+      ip_cidr_range = secondary_ip_range.value["ip_cidr_range"] #"192.168.10.0/24"
+    }
+}
 }
 
 data "google_compute_subnetwork" "created_subnets" {

--- a/main.tf
+++ b/main.tf
@@ -47,8 +47,24 @@ resource "google_compute_subnetwork" "subnetwork" {
   enable_flow_logs         = lookup(var.subnets[count.index], "subnet_flow_logs", "false")
   network                  = google_compute_network.network.name
   project                  = var.project_id
-  secondary_ip_range       = [for i in range(length(contains(keys(var.secondary_ranges), var.subnets[count.index]["subnet_name"]) == true ? var.secondary_ranges[var.subnets[count.index]["subnet_name"]] : [])) : var.secondary_ranges[var.subnets[count.index]["subnet_name"]][i]]
   description              = lookup(var.subnets[count.index], "description", null)
+  #secondary_ip_range       = [for i in range(length(contains(keys(var.secondary_ranges), var.subnets[count.index]["subnet_name"]) == true ? var.secondary_ranges[var.subnets[count.index]["subnet_name"]] : [])) : var.secondary_ranges[var.subnets[count.index]["subnet_name"]][i]]
+
+  secondary_ip_range = var.subnets[count.index]["secondary_ranges"]
+  # secondary_ip_range = [
+  #   for net in var.subnets[count.index]["secondary_ranges"]: {
+  #          range_name = net["range_name"]
+  #          ip_cidr_range = net["ip_cidr_range"]
+  #   }
+  # ]
+   # dynamic "secondary_ip_range" {
+   #   for_each = lookup(var.subnets[count.index], "secondary_ranges", [])
+   #   content {
+   #     range_name = secondary_ip_range.value["range_name"]
+   #     ip_cidr_range = secondary_ip_range.value["ip_cidr_range"]
+   #   }
+   # }
+
 }
 
 data "google_compute_subnetwork" "created_subnets" {

--- a/main.tf
+++ b/main.tf
@@ -43,8 +43,8 @@ resource "google_compute_subnetwork" "subnetwork" {
   name                     = var.subnets[count.index]["subnet_name"]
   ip_cidr_range            = var.subnets[count.index]["subnet_ip"]
   region                   = var.subnets[count.index]["subnet_region"]
-  private_ip_google_access = lookup(var.subnets[count.index], "subnet_private_access", "false")
-  enable_flow_logs         = lookup(var.subnets[count.index], "subnet_flow_logs", "false")
+  private_ip_google_access = var.subnets[count.index]["subnet_private_access"]
+  enable_flow_logs         = var.subnets[count.index]["subnet_flow_logs"]
   network                  = google_compute_network.network.name
   project                  = var.project_id
   description              = lookup(var.subnets[count.index], "description", null)

--- a/main.tf
+++ b/main.tf
@@ -48,23 +48,7 @@ resource "google_compute_subnetwork" "subnetwork" {
   network                  = google_compute_network.network.name
   project                  = var.project_id
   description              = lookup(var.subnets[count.index], "description", null)
-  #secondary_ip_range       = [for i in range(length(contains(keys(var.secondary_ranges), var.subnets[count.index]["subnet_name"]) == true ? var.secondary_ranges[var.subnets[count.index]["subnet_name"]] : [])) : var.secondary_ranges[var.subnets[count.index]["subnet_name"]][i]]
-
-  secondary_ip_range = var.subnets[count.index]["secondary_ranges"]
-  # secondary_ip_range = [
-  #   for net in var.subnets[count.index]["secondary_ranges"]: {
-  #          range_name = net["range_name"]
-  #          ip_cidr_range = net["ip_cidr_range"]
-  #   }
-  # ]
-   # dynamic "secondary_ip_range" {
-   #   for_each = lookup(var.subnets[count.index], "secondary_ranges", [])
-   #   content {
-   #     range_name = secondary_ip_range.value["range_name"]
-   #     ip_cidr_range = secondary_ip_range.value["ip_cidr_range"]
-   #   }
-   # }
-
+  secondary_ip_range       = var.subnets[count.index]["secondary_ranges"]
 }
 
 data "google_compute_subnetwork" "created_subnets" {

--- a/main.tf
+++ b/main.tf
@@ -43,11 +43,11 @@ resource "google_compute_subnetwork" "subnetwork" {
   name                     = var.subnets[count.index]["subnet_name"]
   ip_cidr_range            = var.subnets[count.index]["subnet_ip"]
   region                   = var.subnets[count.index]["subnet_region"]
-  private_ip_google_access = lookup(var.subnets[count.index], "subnet_private_access", "false")
-  enable_flow_logs         = lookup(var.subnets[count.index], "subnet_flow_logs", "false")
+  private_ip_google_access = var.subnets[count.index]["subnet_private_access"]
+  enable_flow_logs         = var.subnets[count.index]["subnet_flow_logs"]
   network                  = google_compute_network.network.name
   project                  = var.project_id
-  description              = lookup(var.subnets[count.index], "description", null)
+  description              = var.subnets[count.index]["description"]
   #secondary_ip_range       = var.subnets[count.index]["secondary_ranges"]
   dynamic "secondary_ip_range" {
     for_each = var.subnets[count.index]["secondary_ranges"]

--- a/main.tf
+++ b/main.tf
@@ -48,14 +48,14 @@ resource "google_compute_subnetwork" "subnetwork" {
   network                  = google_compute_network.network.name
   project                  = var.project_id
   description              = var.subnets[count.index]["description"]
-  #secondary_ip_range       = var.subnets[count.index]["secondary_ranges"]
+
   dynamic "secondary_ip_range" {
     for_each = var.subnets[count.index]["secondary_ranges"]
     content {
-      range_name    = secondary_ip_range.value["range_name"] #"tf-test-secondary-range-update1"
-      ip_cidr_range = secondary_ip_range.value["ip_cidr_range"] #"192.168.10.0/24"
+      range_name    = secondary_ip_range.value["range_name"]
+      ip_cidr_range = secondary_ip_range.value["ip_cidr_range"]
     }
-}
+  }
 }
 
 data "google_compute_subnetwork" "created_subnets" {

--- a/test/integration/secondary_ranges/controls/gcloud.rb
+++ b/test/integration/secondary_ranges/controls/gcloud.rb
@@ -45,6 +45,33 @@ control "gcloud" do
     end
   end
 
+  describe command("gcloud compute networks subnets describe #{network_name}-subnet-01 --project=#{project_id} --region=us-central1 --format=json") do
+    its(:exit_status) { should eq 0 }
+    its(:stderr) { should eq '' }
+
+    let(:data) do
+      if subject.exit_status == 0
+        JSON.parse(subject.stdout)
+      else
+        {}
+      end
+    end
+
+    it "should have the correct secondaryIpRanges configuration for #{network_name}-subnet-01-01" do
+      expect(data["secondaryIpRanges"][0]).to include(
+        "rangeName"   => "#{network_name}-subnet-01-01",
+        "ipCidrRange" => "192.168.67.0/24"
+      )
+    end
+
+    it "should have the correct secondaryIpRanges configuration for #{network_name}-subnet-01-02" do
+      expect(data["secondaryIpRanges"][1]).to include(
+        "rangeName"   => "#{network_name}-subnet-01-02",
+        "ipCidrRange" => "192.168.68.0/24"
+      )
+    end
+  end
+
   describe command("gcloud compute networks subnets describe #{network_name}-subnet-02 --project=#{project_id} --region=us-west1 --format=json") do
     its(:exit_status) { should eq 0 }
     its(:stderr) { should eq '' }

--- a/test/integration/simple_project/controls/gcloud.rb
+++ b/test/integration/simple_project/controls/gcloud.rb
@@ -58,5 +58,11 @@ control "gcloud" do
         )
       end
     end
+
+    describe "description" do
+      it "should equal 'This subnet has a description'" do
+        expect(data["description"]).to eq 'This subnet has a description'
+      end
+    end
   end
 end

--- a/variables.tf
+++ b/variables.tf
@@ -35,24 +35,18 @@ variable "shared_vpc_host" {
 }
 
 variable "subnets" {
-  #type        = list(map(string))
-  type        = list(object(
+  type = list(object(
     {
       subnet_name           = string
       subnet_ip             = string
       subnet_region         = string
       subnet_flow_logs      = string
       subnet_private_access = string
-      secondary_ranges      = list(object({ range_name = string, ip_cidr_range = string })) #list(map(string))
+      description           = string
+      secondary_ranges      = list(object({ range_name = string, ip_cidr_range = string }))
     }
-    )  )
+  ))
   description = "The list of subnets being created"
-}
-
-variable "secondary_ranges" {
-  type        = map(list(object({ range_name = string, ip_cidr_range = string })))
-  description = "Secondary ranges that will be used in some of the subnets"
-  default     = {}
 }
 
 variable "routes" {

--- a/variables.tf
+++ b/variables.tf
@@ -42,7 +42,7 @@ variable "subnets" {
       subnet_region         = string
       subnet_flow_logs      = string
       subnet_private_access = string
-      secondary_ranges      = list(object({ range_name = string, ip_cidr_range = string }))
+      secondary_ranges      = list(map(string))
     }
   ))
   description = "The list of subnets being created"

--- a/variables.tf
+++ b/variables.tf
@@ -37,10 +37,12 @@ variable "shared_vpc_host" {
 variable "subnets" {
   type = list(object(
     {
-      subnet_name      = string
-      subnet_ip        = string
-      subnet_region    = string
-      secondary_ranges = list(object({ range_name = string, ip_cidr_range = string }))
+      subnet_name           = string
+      subnet_ip             = string
+      subnet_region         = string
+      subnet_flow_logs      = string
+      subnet_private_access = string
+      secondary_ranges      = list(object({ range_name = string, ip_cidr_range = string }))
     }
   ))
   description = "The list of subnets being created"

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,7 @@ variable "subnets" {
       subnet_region         = string
       subnet_flow_logs      = string
       subnet_private_access = string
+      description           = string
       secondary_ranges      = list(map(string))
     }
   ))

--- a/variables.tf
+++ b/variables.tf
@@ -42,7 +42,6 @@ variable "subnets" {
       subnet_region         = string
       subnet_flow_logs      = string
       subnet_private_access = string
-      description           = string
       secondary_ranges      = list(object({ range_name = string, ip_cidr_range = string }))
     }
   ))

--- a/variables.tf
+++ b/variables.tf
@@ -37,12 +37,10 @@ variable "shared_vpc_host" {
 variable "subnets" {
   type = list(object(
     {
-      subnet_name           = string
-      subnet_ip             = string
-      subnet_region         = string
-      subnet_flow_logs      = string
-      subnet_private_access = string
-      secondary_ranges      = list(object({ range_name = string, ip_cidr_range = string }))
+      subnet_name      = string
+      subnet_ip        = string
+      subnet_region    = string
+      secondary_ranges = list(object({ range_name = string, ip_cidr_range = string }))
     }
   ))
   description = "The list of subnets being created"

--- a/variables.tf
+++ b/variables.tf
@@ -35,7 +35,17 @@ variable "shared_vpc_host" {
 }
 
 variable "subnets" {
-  type        = list(map(string))
+  #type        = list(map(string))
+  type        = list(object(
+    {
+      subnet_name           = string
+      subnet_ip             = string
+      subnet_region         = string
+      subnet_flow_logs      = string
+      subnet_private_access = string
+      secondary_ranges      = list(object({ range_name = string, ip_cidr_range = string })) #list(map(string))
+    }
+    )  )
   description = "The list of subnets being created"
 }
 


### PR DESCRIPTION
This PR removes secondary_ranges as an input variable and moves it to the subnets list.   I wasn't able to use dynamics blocs which was my original intent, the https://www.terraform.io/docs/providers/google/r/compute_subnetwork.html#secondary_ip_range parameter uses attributes as blocks rather then dynamic blocks for backwards compatibility.   

I also changed the `subnets` to be a list of objects rather than a list of maps, since I needed to mix and match types.  Because I wanted the `secondary_ranges`  entry in the object be a list of maps, I had to define it's type, which has the result of making the secondary_ranges key required. Which is a bummer because I know that was just made optional recently. 

I think this PR will require a bit of clean up, examples and test, but I wanted to open it to highlight my proposed change. 

The subnets parameter would look something like this : 

```Hcl

  subnets          = [
    {
      subnet_name           = "subnet1"
      subnet_ip             = "10.175.0.0/16"
      subnet_region         = "asia-east1"
      subnet_flow_logs      = "true"
      subnet_private_access = "true"
      secondary_ranges  = []
    },
    {
      subnet_name           = "subnet2"
      subnet_ip             = "10.178.112.0/20"
      subnet_region         = "asia-east1"
      subnet_flow_logs      = "true"
      subnet_private_access = "true"
      secondary_ranges =       [{
              range_name    = "secondary_range1"
              ip_cidr_range = "10.183.0.0/16"
            },
            {
              range_name    = "secondary_range2"
              ip_cidr_range = "10.178.128.0/20"
            },
          ]
    },
```