### PR TITLE
Add dynamic rules to Fabric firewall submodule

### DIFF
--- a/modules/fabric-net-firewall/.gitignore
+++ b/modules/fabric-net-firewall/.gitignore
@@ -1,0 +1,1 @@
+terraform.tfvars

--- a/modules/fabric-net-firewall/README.md
+++ b/modules/fabric-net-firewall/README.md
@@ -6,7 +6,7 @@ The HTTP and HTTPS rules use the same network tags that are assigned to instance
 
 All IP source ranges are configurable through variables, and are set by default to `0.0.0.0/0` for tag-based rules. Allowed protocols and/or ports for the intra-VPC rule are also configurable through a variable.
 
-Custom rules are set through a map where key is the rule name, and values must match this custom type:
+Custom rules are set through a map where keys are rule names, and values use this custom type:
 
 ```hcl
 map(object({

--- a/modules/fabric-net-firewall/README.md
+++ b/modules/fabric-net-firewall/README.md
@@ -16,7 +16,7 @@ map(object({
   ranges               = list(string) # list of IP CIDR ranges
   sources              = list(string) # tags or SAs (ignored for EGRESS)
   targets              = list(string) # tags or SAs
-  use_service_accounts = bool         # defaults to false
+  use_service_accounts = bool         # use tags or SAs in sources/targets
   rules = list(object({
     protocol = string
     ports    = list(string)

--- a/modules/fabric-net-firewall/README.md
+++ b/modules/fabric-net-firewall/README.md
@@ -1,10 +1,29 @@
-# Google Cloud Simple VPC Firewall Creation
+# Google Cloud VPC Firewall
 
-This module allows creation of a minimal VPC firewall, supporting basic configurable rules for IP range-based intra-VPC and administrator ingress, and tag-based SSH, HTTP, and HTTPS ingress.
+This module allows creation of a minimal VPC firewall, supporting basic configurable rules for IP range-based intra-VPC and administrator ingress,  tag-based SSH/HTTP/HTTPS ingress, and custom rule definitions.
 
-The HTTP and HTTPS rules use the same network tags network tags that are assigned to instances when flaggging the "Allow HTTP[S] traffic" checkbox in the Cloud Console. The SSH rule uses a generic `ssh` tag.
+The HTTP and HTTPS rules use the same network tags that are assigned to instances when the "Allow HTTP[S] traffic" checkbox is flagged in the Cloud Console. The SSH rule uses a generic `ssh` tag.
 
 All IP source ranges are configurable through variables, and are set by default to `0.0.0.0/0` for tag-based rules. Allowed protocols and/or ports for the intra-VPC rule are also configurable through a variable.
+
+Custom rules are set through a map where key is the rule name, and values must match this custom type:
+
+```hcl
+map(object({
+  description          = string
+  direction            = string       # (INGRESS|EGRESS)
+  action               = string       # (allow|deny)
+  ranges               = list(string) # list of IP CIDR ranges
+  sources              = list(string) # tags or SAs (ignored for EGRESS)
+  targets              = list(string) # tags or SAs
+  use_service_accounts = bool         # defaults to false
+  rules = list(object({
+    protocol = string
+    ports    = list(string)
+  }))
+  extra_attributes = map(string)      # map, optional keys disabled or priority
+}))
+```
 
 The resources created/managed by this module are:
 
@@ -13,6 +32,7 @@ The resources created/managed by this module are:
 - one optional ingress rule for SSH on network tag `ssh`
 - one optional ingress rule for HTTP on network tag `http-server`
 - one optional ingress rule for HTTPS on network tag `https-server`
+- one or more optional custom rules
 
 
 ## Usage
@@ -26,6 +46,24 @@ module "net-firewall" {
   network                 = "my-vpc"
   internal_ranges_enabled = true
   internal_ranges         = ["10.0.0.0/0"]
+  custom_rules = {
+    ingress-sample = {
+      description          = "Dummy sample ingress rule, tag-based."
+      direction            = "INGRESS"
+      action               = "allow"
+      ranges               = ["192.168.0.0"]
+      sources              = ["spam-tag"]
+      targets              = ["foo-tag", "egg-tag"]
+      use_service_accounts = false
+      rules = [
+        {
+          protocol = "tcp"
+          ports    = []
+        }
+      ]
+      extra_attributes = {}
+    }
+  }
 }
 ```
 

--- a/modules/fabric-net-firewall/README.md
+++ b/modules/fabric-net-firewall/README.md
@@ -36,6 +36,7 @@ module "net-firewall" {
 |------|-------------|:----:|:-----:|:-----:|
 | admin\_ranges | IP CIDR ranges that have complete access to all subnets. | list | `<list>` | no |
 | admin\_ranges\_enabled | Enable admin ranges-based rules. | string | `"false"` | no |
+| custom\_rules | List of custom rule definitions (refer to variables file for syntax). | map | `<map>` | no |
 | http\_source\_ranges | List of IP CIDR ranges for tag-based HTTP rule, defaults to 0.0.0.0/0. | list | `<list>` | no |
 | https\_source\_ranges | List of IP CIDR ranges for tag-based HTTPS rule, defaults to 0.0.0.0/0. | list | `<list>` | no |
 | internal\_allow | Allow rules for internal ranges. | list | `<list>` | no |

--- a/modules/fabric-net-firewall/main.tf
+++ b/modules/fabric-net-firewall/main.tf
@@ -121,7 +121,7 @@ resource "google_compute_firewall" "custom" {
   destination_ranges      = each.value.direction == "EGRESS" ? each.value.ranges : null
   source_tags             = each.value.use_service_accounts || each.value.direction == "EGRESS" ? null : each.value.sources
   target_tags             = each.value.use_service_accounts ? null : each.value.targets
-  source_service_accounts = each.value.use_service_accounts ? each.value.sources : null
+  source_service_accounts = each.value.use_service_accounts && each.value.direction == "INGRESS" ? each.value.sources : null
   target_service_accounts = each.value.use_service_accounts ? each.value.targets : null
   disabled                = lookup(each.value.extra_attributes, "disabled", false)
   priority                = lookup(each.value.extra_attributes, "priority", 1000)

--- a/modules/fabric-net-firewall/main.tf
+++ b/modules/fabric-net-firewall/main.tf
@@ -109,9 +109,9 @@ resource "google_compute_firewall" "allow-tag-https" {
 #                                dynamic rules                                 #
 ################################################################################
 
-resource "google_compute_firewall" "dynamic" {
+resource "google_compute_firewall" "custom" {
   # provider                = "google-beta"
-  for_each                = var.dynamic_rules
+  for_each                = var.custom_rules
   name                    = each.key
   description             = each.value.description
   direction               = each.value.direction
@@ -119,7 +119,7 @@ resource "google_compute_firewall" "dynamic" {
   project                 = var.project_id
   source_ranges           = each.value.direction == "INGRESS" ? each.value.ranges : null
   destination_ranges      = each.value.direction == "EGRESS" ? each.value.ranges : null
-  source_tags             = each.value.use_service_accounts ? null : each.value.sources
+  source_tags             = each.value.use_service_accounts || each.value.direction == "EGRESS" ? null : each.value.sources
   target_tags             = each.value.use_service_accounts ? null : each.value.targets
   source_service_accounts = each.value.use_service_accounts ? each.value.sources : null
   target_service_accounts = each.value.use_service_accounts ? each.value.targets : null

--- a/modules/fabric-net-firewall/main.tf
+++ b/modules/fabric-net-firewall/main.tf
@@ -120,8 +120,8 @@ resource "google_compute_firewall" "custom" {
   source_ranges           = each.value.direction == "INGRESS" ? each.value.ranges : null
   destination_ranges      = each.value.direction == "EGRESS" ? each.value.ranges : null
   source_tags             = each.value.use_service_accounts || each.value.direction == "EGRESS" ? null : each.value.sources
-  target_tags             = each.value.use_service_accounts ? null : each.value.targets
   source_service_accounts = each.value.use_service_accounts && each.value.direction == "INGRESS" ? each.value.sources : null
+  target_tags             = each.value.use_service_accounts ? null : each.value.targets
   target_service_accounts = each.value.use_service_accounts ? each.value.targets : null
   disabled                = lookup(each.value.extra_attributes, "disabled", false)
   priority                = lookup(each.value.extra_attributes, "priority", 1000)

--- a/modules/fabric-net-firewall/outputs.tf
+++ b/modules/fabric-net-firewall/outputs.tf
@@ -32,3 +32,34 @@ output "admin_ranges" {
   }
 }
 
+output "custom_ingress_allow_rules" {
+  description = "Custom ingress rules with allow blocks."
+  value = [
+    for rule in google_compute_firewall.custom :
+    rule.name if rule.direction == "INGRESS" && length(rule.allow) > 0
+  ]
+}
+
+output "custom_ingress_deny_rules" {
+  description = "Custom ingress rules with deny blocks."
+  value = [
+    for rule in google_compute_firewall.custom :
+    rule.name if rule.direction == "INGRESS" && length(rule.deny) > 0
+  ]
+}
+
+output "custom_egress_allow_rules" {
+  description = "Custom egress rules with allow blocks."
+  value = [
+    for rule in google_compute_firewall.custom :
+    rule.name if rule.direction == "EGRESS" && length(rule.allow) > 0
+  ]
+}
+
+output "custom_egress_deny_rules" {
+  description = "Custom egress rules with allow blocks."
+  value = [
+    for rule in google_compute_firewall.custom :
+    rule.name if rule.direction == "EGRESS" && length(rule.deny) > 0
+  ]
+}

--- a/modules/fabric-net-firewall/variables.tf
+++ b/modules/fabric-net-firewall/variables.tf
@@ -66,8 +66,8 @@ variable "https_source_ranges" {
   default     = ["0.0.0.0/0"]
 }
 
-variable "dynamic_rules" {
-  description = "List of dynamic rule definitions."
+variable "custom_rules" {
+  description = "List of custom rule definitions."
   type = map(object({
     description          = string
     direction            = string

--- a/modules/fabric-net-firewall/variables.tf
+++ b/modules/fabric-net-firewall/variables.tf
@@ -67,7 +67,8 @@ variable "https_source_ranges" {
 }
 
 variable "custom_rules" {
-  description = "List of custom rule definitions."
+  description = "List of custom rule definitions (refer to variables file for syntax)."
+  default     = {}
   type = map(object({
     description          = string
     direction            = string

--- a/modules/fabric-net-firewall/variables.tf
+++ b/modules/fabric-net-firewall/variables.tf
@@ -65,3 +65,45 @@ variable "https_source_ranges" {
   description = "List of IP CIDR ranges for tag-based HTTPS rule, defaults to 0.0.0.0/0."
   default     = ["0.0.0.0/0"]
 }
+
+variable "ingress_rules" {
+  description = "List of ingress rule definitions."
+  type = map(object({
+    description   = string
+    source_ranges = list(string)
+    source_tags   = list(string)
+    # target is tags or service_accounts
+    target_type   = string
+    target_values = list(string)
+    allow = list(object({
+      protocol = string
+      ports    = list(string)
+    }))
+    deny = list(object({
+      protocol = string
+      ports    = list(string)
+    }))
+    extra_attributes = map(string)
+  }))
+}
+
+variable "egress_rules" {
+  description = "List of egress rule definitions."
+  type = map(object({
+    description   = string
+    source_ranges = list(string)
+    source_tags   = list(string)
+    # target is tags or service_accounts
+    target_type   = string
+    target_values = list(string)
+    allow = list(object({
+      protocol = string
+      ports    = list(string)
+    }))
+    deny = list(object({
+      protocol = string
+      ports    = list(string)
+    }))
+    extra_attributes = map(string)
+  }))
+}

--- a/modules/fabric-net-firewall/variables.tf
+++ b/modules/fabric-net-firewall/variables.tf
@@ -66,41 +66,17 @@ variable "https_source_ranges" {
   default     = ["0.0.0.0/0"]
 }
 
-variable "ingress_rules" {
-  description = "List of ingress rule definitions."
+variable "dynamic_rules" {
+  description = "List of dynamic rule definitions."
   type = map(object({
-    description   = string
-    source_ranges = list(string)
-    source_tags   = list(string)
-    # target is tags or service_accounts
-    target_type   = string
-    target_values = list(string)
-    allow = list(object({
-      protocol = string
-      ports    = list(string)
-    }))
-    deny = list(object({
-      protocol = string
-      ports    = list(string)
-    }))
-    extra_attributes = map(string)
-  }))
-}
-
-variable "egress_rules" {
-  description = "List of egress rule definitions."
-  type = map(object({
-    description   = string
-    source_ranges = list(string)
-    source_tags   = list(string)
-    # target is tags or service_accounts
-    target_type   = string
-    target_values = list(string)
-    allow = list(object({
-      protocol = string
-      ports    = list(string)
-    }))
-    deny = list(object({
+    description          = string
+    direction            = string
+    action               = string # (allow|deny)
+    ranges               = list(string)
+    sources              = list(string)
+    targets              = list(string)
+    use_service_accounts = bool
+    rules = list(object({
       protocol = string
       ports    = list(string)
     }))


### PR DESCRIPTION
Aleks, this is a first shot at adding dynamic rule definitions to the firewall submodule, to make it a bit more flexible.

What I tried to implement here:

- enforcing structure for the rule definitions variable
- combine ingress and egress into a single variable/resource so that the module has few duplications
- correctly handle the incompatibility of tags/service accounts based source and targets

I did some minimal testing and it seems to work. This is an example variable for an ingress rule using both source and target tags, and a source range:

```
dynamic_rules = {
  dummy = {
    description          = "Dummy rule."
    direction            = "INGRESS"
    action               = "allow"
    ranges               = ["192.168.0.0"]
    sources              = ["spam-tag"]
    targets              = ["foo-tag", "egg-tag"]
    use_service_accounts = false
    rules = [
      {
        protocol = "tcp"
        ports    = []
      }
    ]
    extra_attributes = {}
  }
}
```

Can you give it a try and let me know your thoughts?
