### PR TITLE
Make use of GOOGLE_APPLICATION_CREDENTIALS in local-exec script.

### DIFF
--- a/scripts/delete-default-gateway-routes.sh
+++ b/scripts/delete-default-gateway-routes.sh
@@ -36,6 +36,9 @@ function delete_internet_gateway_routes {
   done
 }
 
+if [ -n "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
+  gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
+fi
 
 if [ -n "${FILTERED_ROUTES}" ]; then
   delete_internet_gateway_routes "${FILTERED_ROUTES}"


### PR DESCRIPTION
Fix for #65.