### PR TITLE
Make network creation optional in root module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ docker_test_prepare:
 
 # Clean up test environment within the docker container
 .PHONY: docker_test_cleanup
-docker_test_prepare:
+docker_test_cleanup:
 	docker run --rm -it \
 		-e SERVICE_ACCOUNT_JSON \
 		-e TF_VAR_org_id \

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Then perform the following commands on the root folder:
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | auto\_create\_subnetworks | When set to true, the network is created in 'auto subnet mode' and it will create a subnet for each region automatically across the 10.128.0.0/9 address range. When set to false, the network is created in 'custom subnet mode' so the user can explicitly connect subnetwork resources. | bool | `"false"` | no |
+| create\_network | Specify whether to create a new network or just assume it already exists. | string | `"true"` | no |
 | delete\_default\_internet\_gateway\_routes | If set, ensure that all routes within the network specified whose names begin with 'default-route' and with a next hop of 'default-internet-gateway' are deleted | string | `"false"` | no |
 | description | An optional description of this resource. The resource must be recreated to modify this field. | string | `""` | no |
 | network\_name | The name of the network being created | string | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -37,8 +37,7 @@ data "google_compute_network" "network" {
  *****************************************/
 resource "google_compute_shared_vpc_host_project" "shared_vpc_host" {
   count      = var.shared_vpc_host == "true" ? 1 : 0
-  project    = var.project_id
-  depends_on = [data.google_compute_network.network]
+  project    = data.google_compute_network.network.project
 }
 
 /******************************************
@@ -56,6 +55,7 @@ resource "google_compute_subnetwork" "subnetwork" {
   project                  = var.project_id
   secondary_ip_range       = [for i in range(length(contains(keys(var.secondary_ranges), var.subnets[count.index]["subnet_name"]) == true ? var.secondary_ranges[var.subnets[count.index]["subnet_name"]] : [])) : var.secondary_ranges[var.subnets[count.index]["subnet_name"]][i]]
   description              = lookup(var.subnets[count.index], "description", null)
+  depends_on               = [google_compute_network.network]
 }
 
 data "google_compute_subnetwork" "created_subnets" {
@@ -101,7 +101,7 @@ resource "null_resource" "delete_default_internet_gateway_routes" {
   }
 
   depends_on = [
-    data.google_compute_network.network,
+    google_compute_network.network,
     google_compute_subnetwork.subnetwork,
     google_compute_route.route,
   ]

--- a/main.tf
+++ b/main.tf
@@ -36,8 +36,8 @@ data "google_compute_network" "network" {
 	Shared VPC
  *****************************************/
 resource "google_compute_shared_vpc_host_project" "shared_vpc_host" {
-  count      = var.shared_vpc_host == "true" ? 1 : 0
-  project    = data.google_compute_network.network.project
+  count   = var.shared_vpc_host == "true" ? 1 : 0
+  project = data.google_compute_network.network.project
 }
 
 /******************************************

--- a/main.tf
+++ b/main.tf
@@ -18,11 +18,18 @@
 	VPC configuration
  *****************************************/
 resource "google_compute_network" "network" {
+  count                   = var.create_network == "true" ? 1 : 0
   name                    = var.network_name
   auto_create_subnetworks = var.auto_create_subnetworks
   routing_mode            = var.routing_mode
   project                 = var.project_id
   description             = var.description
+}
+
+data "google_compute_network" "network" {
+  name       = var.network_name
+  project    = var.project_id
+  depends_on = [google_compute_network.network]
 }
 
 /******************************************
@@ -31,7 +38,7 @@ resource "google_compute_network" "network" {
 resource "google_compute_shared_vpc_host_project" "shared_vpc_host" {
   count      = var.shared_vpc_host == "true" ? 1 : 0
   project    = var.project_id
-  depends_on = [google_compute_network.network]
+  depends_on = [data.google_compute_network.network]
 }
 
 /******************************************
@@ -45,7 +52,7 @@ resource "google_compute_subnetwork" "subnetwork" {
   region                   = var.subnets[count.index]["subnet_region"]
   private_ip_google_access = lookup(var.subnets[count.index], "subnet_private_access", "false")
   enable_flow_logs         = lookup(var.subnets[count.index], "subnet_flow_logs", "false")
-  network                  = google_compute_network.network.name
+  network                  = data.google_compute_network.network.name
   project                  = var.project_id
   secondary_ip_range       = [for i in range(length(contains(keys(var.secondary_ranges), var.subnets[count.index]["subnet_name"]) == true ? var.secondary_ranges[var.subnets[count.index]["subnet_name"]] : [])) : var.secondary_ranges[var.subnets[count.index]["subnet_name"]][i]]
   description              = lookup(var.subnets[count.index], "description", null)
@@ -65,7 +72,7 @@ data "google_compute_subnetwork" "created_subnets" {
 resource "google_compute_route" "route" {
   count                  = length(var.routes)
   project                = var.project_id
-  network                = var.network_name
+  network                = data.google_compute_network.network.name
   name                   = lookup(var.routes[count.index], "name", format("%s-%s-%d", lower(var.network_name), "route", count.index))
   description            = lookup(var.routes[count.index], "description", "")
   tags                   = compact(split(",", lookup(var.routes[count.index], "tags", "")))
@@ -78,7 +85,6 @@ resource "google_compute_route" "route" {
   priority               = lookup(var.routes[count.index], "priority", "1000")
 
   depends_on = [
-    google_compute_network.network,
     google_compute_subnetwork.subnetwork,
   ]
 }
@@ -95,7 +101,7 @@ resource "null_resource" "delete_default_internet_gateway_routes" {
   }
 
   depends_on = [
-    google_compute_network.network,
+    data.google_compute_network.network,
     google_compute_subnetwork.subnetwork,
     google_compute_route.route,
   ]

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,12 +15,12 @@
  */
 
 output "network_name" {
-  value       = google_compute_network.network.name
+  value       = data.google_compute_network.network.name
   description = "The name of the VPC being created"
 }
 
 output "network_self_link" {
-  value       = google_compute_network.network.self_link
+  value       = data.google_compute_network.network.self_link
   description = "The URI of the VPC being created"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,12 @@ variable "project_id" {
   description = "The ID of the project where this VPC will be created"
 }
 
+variable "create_network" {
+  type        = string
+  default     = "true"
+  description = "Specify whether to create a new network or just assume it already exists."
+}
+
 variable "network_name" {
   description = "The name of the network being created"
 }


### PR DESCRIPTION
This is a no-impact (by default) change which allows network_creation to be separated from subnet and route creation.  Fixes https://github.com/terraform-google-modules/terraform-google-network/issues/88

Tests are still running locally, but it looks like everything is passing until I run out of network quota, so I'm sending the PR to see if it passes CI.