### PR TITLE
Removing deprecated `enable_flow_logs` setting in favour of log_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The routes list contains maps, where each object represents a route. For the nex
 ## Requirements
 ### Installed Software
 - [Terraform](https://www.terraform.io/downloads.html) ~> 0.12.0
-- [Terraform Provider for GCP][terraform-provider-google] ~> 2.10.0
+- [Terraform Provider for GCP][terraform-provider-google] ~> 2.19.0
 - [gcloud](https://cloud.google.com/sdk/gcloud/) >243.0.0
 
 ### Configure a Service Account

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ module "vpc" {
             subnet_flow_logs      = "true"
             description           = "This subnet has a description"
         },
+        {
+            subnet_name               = "subnet-03"
+            subnet_ip                 = "10.10.30.0/24"
+            subnet_region             = "us-west1",
+            subnet_flow_logs_interval = "INTERVAL_10_MIN",
+            subnet_flow_logs_sampling = 0.5,
+            subnet_flow_logs_metadata = "INCLUDE_ALL_METADATA"
+        }
     ]
 
     secondary_ranges = {

--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ module "vpc" {
         {
             subnet_name               = "subnet-03"
             subnet_ip                 = "10.10.30.0/24"
-            subnet_region             = "us-west1",
-            subnet_flow_logs_interval = "INTERVAL_10_MIN",
-            subnet_flow_logs_sampling = 0.5,
+            subnet_region             = "us-west1"
+            subnet_flow_logs          = "true"
+            subnet_flow_logs_interval = "INTERVAL_10_MIN"
+            subnet_flow_logs_sampling = 0.7
             subnet_flow_logs_metadata = "INCLUDE_ALL_METADATA"
         }
     ]

--- a/examples/delete_default_gateway_routes/main.tf
+++ b/examples/delete_default_gateway_routes/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.10.0"
+  version = "~> 2.19.0"
 }
 
 provider "null" {

--- a/examples/multi_vpc/main.tf
+++ b/examples/multi_vpc/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.10.0"
+  version = "~> 2.19.0"
 }
 
 provider "null" {

--- a/examples/secondary_ranges/main.tf
+++ b/examples/secondary_ranges/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.10.0"
+  version = "~> 2.19.0"
 }
 
 provider "null" {

--- a/examples/simple_project/main.tf
+++ b/examples/simple_project/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.10.0"
+  version = "~> 2.19.0"
 }
 
 provider "null" {
@@ -25,6 +25,7 @@ provider "null" {
 locals {
   subnet_01 = "${var.network_name}-subnet-01"
   subnet_02 = "${var.network_name}-subnet-02"
+  subnet_03 = "${var.network_name}-subnet-03"
 }
 
 module "test-vpc-module" {
@@ -45,5 +46,13 @@ module "test-vpc-module" {
       subnet_private_access = "true"
       subnet_flow_logs      = "true"
     },
+    {
+      subnet_name           = "${local.subnet_03}"
+      subnet_ip             = "10.10.30.0/24"
+      subnet_region         = "us-west1"
+      subnet_flow_logs_interval = "INTERVAL_10_MIN"
+      subnet_flow_logs_sampling = 0.7
+      subnet_flow_logs_metadata = "INCLUDE_ALL_METADATA"
+    }
   ]
 }

--- a/examples/simple_project/main.tf
+++ b/examples/simple_project/main.tf
@@ -50,6 +50,7 @@ module "test-vpc-module" {
       subnet_name               = "${local.subnet_03}"
       subnet_ip                 = "10.10.30.0/24"
       subnet_region             = "us-west1"
+      subnet_flow_logs          = "true"
       subnet_flow_logs_interval = "INTERVAL_10_MIN"
       subnet_flow_logs_sampling = 0.7
       subnet_flow_logs_metadata = "INCLUDE_ALL_METADATA"

--- a/examples/simple_project/main.tf
+++ b/examples/simple_project/main.tf
@@ -47,9 +47,9 @@ module "test-vpc-module" {
       subnet_flow_logs      = "true"
     },
     {
-      subnet_name           = "${local.subnet_03}"
-      subnet_ip             = "10.10.30.0/24"
-      subnet_region         = "us-west1"
+      subnet_name               = "${local.subnet_03}"
+      subnet_ip                 = "10.10.30.0/24"
+      subnet_region             = "us-west1"
       subnet_flow_logs_interval = "INTERVAL_10_MIN"
       subnet_flow_logs_sampling = 0.7
       subnet_flow_logs_metadata = "INCLUDE_ALL_METADATA"

--- a/examples/simple_project_with_regional_network/main.tf
+++ b/examples/simple_project_with_regional_network/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.10.0"
+  version = "~> 2.19.0"
 }
 
 provider "null" {

--- a/examples/submodule_firewall/main.tf
+++ b/examples/submodule_firewall/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.10.0"
+  version = "~> 2.19.0"
 }
 
 provider "null" {

--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,7 @@ resource "google_compute_subnetwork" "subnetwork" {
   region                   = each.value.subnet_region
   private_ip_google_access = lookup(each.value, "subnet_private_access", "false")
   dynamic "log_config" {
-    for_each = lookup(each.value, "subnet_flow_logs", false) || lookup(each.value, "subnet_flow_logs_interval", null) != null || lookup(each.value, "subnet_flow_logs_sampling", null) != null || lookup(each.value, "subnet_flow_logs_metadata", null) != null ? [{
+    for_each = lookup(each.value, "subnet_flow_logs", false) ? [{
       aggregation_interval = lookup(each.value, "subnet_flow_logs_interval", null)
       flow_sampling        = lookup(each.value, "subnet_flow_logs_sampling", null)
       metadata             = lookup(each.value, "subnet_flow_logs_metadata", null)

--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,18 @@ resource "google_compute_subnetwork" "subnetwork" {
   ip_cidr_range            = each.value.subnet_ip
   region                   = each.value.subnet_region
   private_ip_google_access = lookup(each.value, "subnet_private_access", "false")
-  enable_flow_logs         = lookup(each.value, "subnet_flow_logs", "false")
+  dynamic "log_config" {
+    for_each = lookup(each.value, "subnet_flow_logs", false) || lookup(each.value, "subnet_flow_logs_interval", null) != null || lookup(each.value, "subnet_flow_logs_sampling", null) != null ||  lookup(each.value, "subnet_flow_logs_metadata", null) != null ? [{
+      aggregation_interval = lookup(each.value, "subnet_flow_logs_interval", null)
+      flow_sampling = lookup(each.value, "subnet_flow_logs_sampling", null)
+      metadata = lookup(each.value, "subnet_flow_logs_metadata", null)
+    }] : []
+    content {
+      aggregation_interval = log_config.value.aggregation_interval
+      flow_sampling = log_config.value.flow_sampling
+      metadata = log_config.value.metadata
+    }
+  }
   network                  = google_compute_network.network.name
   project                  = var.project_id
   description              = lookup(each.value, "description", null)

--- a/main.tf
+++ b/main.tf
@@ -51,20 +51,20 @@ resource "google_compute_subnetwork" "subnetwork" {
   region                   = each.value.subnet_region
   private_ip_google_access = lookup(each.value, "subnet_private_access", "false")
   dynamic "log_config" {
-    for_each = lookup(each.value, "subnet_flow_logs", false) || lookup(each.value, "subnet_flow_logs_interval", null) != null || lookup(each.value, "subnet_flow_logs_sampling", null) != null ||  lookup(each.value, "subnet_flow_logs_metadata", null) != null ? [{
+    for_each = lookup(each.value, "subnet_flow_logs", false) || lookup(each.value, "subnet_flow_logs_interval", null) != null || lookup(each.value, "subnet_flow_logs_sampling", null) != null || lookup(each.value, "subnet_flow_logs_metadata", null) != null ? [{
       aggregation_interval = lookup(each.value, "subnet_flow_logs_interval", null)
-      flow_sampling = lookup(each.value, "subnet_flow_logs_sampling", null)
-      metadata = lookup(each.value, "subnet_flow_logs_metadata", null)
+      flow_sampling        = lookup(each.value, "subnet_flow_logs_sampling", null)
+      metadata             = lookup(each.value, "subnet_flow_logs_metadata", null)
     }] : []
     content {
       aggregation_interval = log_config.value.aggregation_interval
-      flow_sampling = log_config.value.flow_sampling
-      metadata = log_config.value.metadata
+      flow_sampling        = log_config.value.flow_sampling
+      metadata             = log_config.value.metadata
     }
   }
-  network                  = google_compute_network.network.name
-  project                  = var.project_id
-  description              = lookup(each.value, "description", null)
+  network     = google_compute_network.network.name
+  project     = var.project_id
+  description = lookup(each.value, "description", null)
   secondary_ip_range = [
     for i in range(
       length(

--- a/test/integration/simple_project/controls/gcloud.rb
+++ b/test/integration/simple_project/controls/gcloud.rb
@@ -30,12 +30,16 @@ control "gcloud" do
       end
     end
 
-    describe "enableFlowLogs" do
-      it "should be false" do
-        expect(data).to include(
-          "enableFlowLogs" => false
-        )
-      end
+    it "enableFlowLogs should not exist" do
+      expect(data).to_not include(
+        "enableFlowLogs"
+      )
+    end
+
+    it "logConfig should not exist" do
+      expect(data).to_not include(
+        "logConfig"
+      )
     end
   end
 
@@ -51,12 +55,51 @@ control "gcloud" do
       end
     end
 
-    describe "enableFlowLogs" do
-      it "should be true" do
-        expect(data).to include(
-          "enableFlowLogs" => true
-        )
+    it "enableFlowLogs should be true" do
+      expect(data).to include(
+        "enableFlowLogs" => true
+      )
+    end
+
+    it "Log config should be correct" do
+      expect(data).to include(
+        "logConfig" => {
+          "aggregationInterval" => "INTERVAL_5_SEC",
+          "enable" => true,
+          "flowSampling" => 0.5,
+          "metadata" => "INCLUDE_ALL_METADATA"
+        }
+      )
+    end
+  end
+
+  describe  command("gcloud compute networks subnets describe #{network_name}-subnet-03 --project=#{project_id} --region=us-west1 --format=json") do
+    its(:exit_status) { should eq 0 }
+    its(:stderr) { should eq '' }
+
+    let(:data) do
+      if subject.exit_status == 0
+        JSON.parse(subject.stdout)
+      else
+        {}
       end
+    end
+
+    it "enableFlowLogs should be true" do
+      expect(data).to include(
+        "enableFlowLogs" => true
+      )
+    end
+
+    it "Log config should be correct" do
+      expect(data).to include(
+        "logConfig" => {
+          "aggregationInterval" => "INTERVAL_10_MIN",
+          "enable" => true,
+          "flowSampling" => 0.7,
+          "metadata" => "INCLUDE_ALL_METADATA"
+        }
+      )
     end
   end
 end

--- a/test/integration/simple_project/controls/gcloud.rb
+++ b/test/integration/simple_project/controls/gcloud.rb
@@ -30,12 +30,6 @@ control "gcloud" do
       end
     end
 
-    it "enableFlowLogs should not exist" do
-      expect(data).to_not include(
-        "enableFlowLogs"
-      )
-    end
-
     it "logConfig should not exist" do
       expect(data).to_not include(
         "logConfig"
@@ -53,12 +47,6 @@ control "gcloud" do
       else
         {}
       end
-    end
-
-    it "enableFlowLogs should be true" do
-      expect(data).to include(
-        "enableFlowLogs" => true
-      )
     end
 
     it "Log config should be correct" do
@@ -83,12 +71,6 @@ control "gcloud" do
       else
         {}
       end
-    end
-
-    it "enableFlowLogs should be true" do
-      expect(data).to include(
-        "enableFlowLogs" => true
-      )
     end
 
     it "Log config should be correct" do

--- a/test/integration/simple_project/controls/gcp.rb
+++ b/test/integration/simple_project/controls/gcp.rb
@@ -44,4 +44,14 @@ control "gcp" do
     its('ip_cidr_range') { should eq "10.10.20.0/24" }
     its('private_ip_google_access') { should be true }
   end
+
+  describe google_compute_subnetwork(
+    project: project_id,
+    name: "#{network_name}-subnet-03",
+    region: "us-west1"
+  ) do
+    it { should exist }
+    its('ip_cidr_range') { should eq "10.10.30.0/24" }
+    its('private_ip_google_access') { should be false }
+  end
 end


### PR DESCRIPTION
When using this module with the latest Google provider, I noticed a warning about the deprecation of the `enable_flow_logs` setting in the `google_compute_subnetwork`. This was raised #105.  
This PR uses a dynamic block to define the `log_config` of a subnetwork if any of:
- `subnet_flow_logs_interval`
- `subnet_flow_logs_sampling`
- `subnet_flow_logs_metadata`  

are set. Or `subnet_flow_logs`is true. 