### PR TITLE
Add subnet_log_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Then perform the following commands on the root folder:
 | routing\_mode | The network routing mode (default 'GLOBAL') | string | `"GLOBAL"` | no |
 | secondary\_ranges | Secondary ranges that will be used in some of the subnets | object | `<map>` | no |
 | shared\_vpc\_host | Makes this project a Shared VPC host if 'true' (default 'false') | string | `"false"` | no |
+| subnet\_log\_config | If a value is set, flow logging for this subnetwork will be enabled. | map | `<map>` | no |
 | subnets | The list of subnets being created | list(map(string)) | n/a | yes |
 
 ## Outputs

--- a/examples/multi_vpc/main.tf
+++ b/examples/multi_vpc/main.tf
@@ -68,21 +68,33 @@ module "test-vpc-module-01" {
       subnet_ip             = "10.10.10.0/24"
       subnet_region         = "us-west1"
       subnet_private_access = "false"
-      subnet_flow_logs      = "true"
+      subnet_log_config     = {
+        aggregation_interval = "INTERVAL_10_MIN"
+        flow_sampling        = 0.5
+        metadata             = "INCLUDE_ALL_METADATA"
+      }
     },
     {
       subnet_name           = local.network_01_subnet_02
       subnet_ip             = "10.10.20.0/24"
       subnet_region         = "us-west1"
       subnet_private_access = "false"
-      subnet_flow_logs      = "true"
+      subnet_log_config     = {
+        aggregation_interval = "INTERVAL_10_MIN"
+        flow_sampling        = 0.5
+        metadata             = "INCLUDE_ALL_METADATA"
+      }
     },
     {
       subnet_name           = local.network_01_subnet_03
       subnet_ip             = "10.10.30.0/24"
       subnet_region         = "us-west1"
       subnet_private_access = "false"
-      subnet_flow_logs      = "true"
+      subnet_log_config     = {
+        aggregation_interval = "INTERVAL_10_MIN"
+        flow_sampling        = 0.5
+        metadata             = "INCLUDE_ALL_METADATA"
+      }
     },
   ]
 
@@ -120,14 +132,22 @@ module "test-vpc-module-02" {
       subnet_ip             = "10.10.40.0/24"
       subnet_region         = "us-west1"
       subnet_private_access = "false"
-      subnet_flow_logs      = "true"
+      subnet_log_config     = {
+        aggregation_interval = "INTERVAL_10_MIN"
+        flow_sampling        = 0.5
+        metadata             = "INCLUDE_ALL_METADATA"
+      }
     },
     {
       subnet_name           = "${local.network_02_subnet_02}"
       subnet_ip             = "10.10.50.0/24"
       subnet_region         = "us-west1"
       subnet_private_access = "false"
-      subnet_flow_logs      = "true"
+      subnet_log_config     = {
+        aggregation_interval = "INTERVAL_10_MIN"
+        flow_sampling        = 0.5
+        metadata             = "INCLUDE_ALL_METADATA"
+      }
     },
   ]
 

--- a/examples/secondary_ranges/main.tf
+++ b/examples/secondary_ranges/main.tf
@@ -45,7 +45,11 @@ module "vpc-secondary-ranges" {
       subnet_ip             = "10.10.20.0/24"
       subnet_region         = "us-west1"
       subnet_private_access = "true"
-      subnet_flow_logs      = "true"
+      subnet_log_config     = {
+        aggregation_interval = "INTERVAL_10_MIN"
+        flow_sampling        = 0.5
+        metadata             = "INCLUDE_ALL_METADATA"
+      }
     },
     {
       subnet_name   = "${local.subnet_03}"

--- a/examples/simple_project/main.tf
+++ b/examples/simple_project/main.tf
@@ -43,7 +43,11 @@ module "test-vpc-module" {
       subnet_ip             = "10.10.20.0/24"
       subnet_region         = "us-west1"
       subnet_private_access = "true"
-      subnet_flow_logs      = "true"
+      subnet_log_config     = {
+        aggregation_interval = "INTERVAL_10_MIN"
+        flow_sampling        = 0.5
+        metadata             = "INCLUDE_ALL_METADATA"
+      }
     },
   ]
 }

--- a/examples/simple_project_with_regional_network/main.tf
+++ b/examples/simple_project_with_regional_network/main.tf
@@ -44,7 +44,11 @@ module "test-vpc-module" {
       subnet_ip             = "10.10.20.0/24"
       subnet_region         = "us-west1"
       subnet_private_access = "true"
-      subnet_flow_logs      = "true"
+      subnet_log_config     = {
+        aggregation_interval = "INTERVAL_10_MIN"
+        flow_sampling        = 0.5
+        metadata             = "INCLUDE_ALL_METADATA"
+      }
     },
   ]
 }

--- a/examples/submodule_firewall/main.tf
+++ b/examples/submodule_firewall/main.tf
@@ -43,7 +43,11 @@ module "test-vpc-module" {
       subnet_ip             = "10.10.20.0/24"
       subnet_region         = "us-west1"
       subnet_private_access = "true"
-      subnet_flow_logs      = "true"
+      subnet_log_config     = {
+        aggregation_interval = "INTERVAL_10_MIN"
+        flow_sampling        = 0.5
+        metadata             = "INCLUDE_ALL_METADATA"
+      }
     },
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,12 @@ variable "subnets" {
   description = "The list of subnets being created"
 }
 
+variable "subnet_log_config" {
+  type        = "map"
+  description = "If a value is set, flow logging for this subnetwork will be enabled."
+  default     = {}
+}
+
 variable "secondary_ranges" {
   type        = map(list(object({ range_name = string, ip_cidr_range = string })))
   description = "Secondary ranges that will be used in some of the subnets"


### PR DESCRIPTION
1) Since the "enable_flow_logs" var is deprecated in favor of "log_config" block, this PR adds the "subnet_log_config" var that receives a map and parses it to the "log_config" .
This PR also updates the examples with this change.
2) In the file main.tf of this module, this PR applies a fix the lint on the google_compute_route.route resource. 