### PR TITLE
add subnets output

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Then perform the following commands on the root folder:
 | network\_self\_link | The URI of the VPC being created |
 | project\_id | VPC project id |
 | route\_names | The route names associated with this VPC |
+| subnets | A map with keys of form subnet_region/subnet_name and values being the outputs of the google_compute_subnetwork resources used to create corresponding subnets. |
 | subnets\_flow\_logs | Whether the subnets will have VPC flow logs enabled |
 | subnets\_ips | The IPs and CIDRs of the subnets being created |
 | subnets\_names | The names of the subnets being created |

--- a/outputs.tf
+++ b/outputs.tf
@@ -68,3 +68,7 @@ output "route_names" {
   value       = [for route in module.routes.routes : route.name]
   description = "The route names associated with this VPC"
 }
+
+output "subnets" {
+  value = module.subnets.subnets
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -70,5 +70,6 @@ output "route_names" {
 }
 
 output "subnets" {
-  value = module.subnets.subnets
+  value       = module.subnets.subnets
+  description = "A map with keys of form subnet_region/subnet_name and values being the outputs of the google_compute_subnetwork resources used to create corresponding subnets."
 }


### PR DESCRIPTION
which is a map with keys `"${subnet_region}/${subnet_name}"` and values being the outputs
of the `google_compute_subnetwork` resource

with this output other modules can obtain data such as `self_link` for particular
subnets without running into resource recreation problems etc. when the number/order
of the subnets changes