### PR TITLE
fix: service_project_ids type

### DIFF
--- a/modules/fabric-net-svpc-access/README.md
+++ b/modules/fabric-net-svpc-access/README.md
@@ -46,7 +46,7 @@ module "net-shared-vpc-access" {
 | host\_subnet\_regions | List of subnet regions, one per subnet. | list | `<list>` | no |
 | host\_subnet\_users | Map of comma-delimited IAM-style members to which network user roles for subnets will be assigned. | map | `<map>` | no |
 | host\_subnets | List of subnet names on which to grant network user role. | list | `<list>` | no |
-| service\_project\_ids | Ids of the service projects that will be attached to the Shared VPC. | list | n/a | yes |
+| service\_project\_ids | Ids of the service projects that will be attached to the Shared VPC. | list(string) | n/a | yes |
 | service\_project\_num | Number of service projects that will be attached to the Shared VPC. | string | `"0"` | no |
 
 ## Outputs

--- a/modules/fabric-net-svpc-access/variables.tf
+++ b/modules/fabric-net-svpc-access/variables.tf
@@ -27,7 +27,7 @@ variable "service_project_num" {
 
 variable "service_project_ids" {
   description = "Ids of the service projects that will be attached to the Shared VPC."
-  type        = "list"
+  type        = list(string)
 }
 
 variable "host_subnets" {


### PR DESCRIPTION
Quoted type constraints are deprecated.

```
Warning: Quoted type constraints are deprecated

  on .terraform/modules/-.network_fabric-net-svpc-access/terraform-google-modules-terraform-google-network-270efc6/modules/fabric-net-svpc-access/variables.tf line 30, in variable "service_project_ids":
  30:   type        = "list"

Terraform 0.11 and earlier required type constraints to be given in quotes,
but that form is now deprecated and will be removed in a future version of
Terraform. To silence this warning, remove the quotes around "list" and write
list(string) instead to explicitly indicate that the list elements are
strings.
```