### PR TITLE
fix the "Invalid expanding argument value" issue with the newer tfs

### DIFF
--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -30,6 +30,6 @@ output "network_self_link" {
 }
 
 output "project_id" {
-  value       = var.shared_vpc_host ? coalesce(google_compute_shared_vpc_host_project.shared_vpc_host.*.project...) : google_compute_network.network.project
+  value       = var.shared_vpc_host ? coalesce(flatten([google_compute_shared_vpc_host_project.shared_vpc_host.*.project])...) : google_compute_network.network.project
   description = "VPC project id"
 }


### PR DESCRIPTION
Getting the following error when trying to access the output variable "project_id" of the vpc module
```
Error: Invalid expanding argument value

  on .terraform/modules/apps-projects.vpc/modules/vpc/outputs.tf line 33, in output "project_id":
  33:   value       = var.shared_vpc_host ? coalesce(google_compute_shared_vpc_host_project.shared_vpc_host.*.project...) : google_compute_network.network.project

The expanding argument (indicated by ...) must be of a tuple, list, or set type.

```

Seems related to a known issue with newest versions of terraform:
https://github.com/hashicorp/terraform/issues/22404
https://github.com/hashicorp/terraform/issues/22576

Can reproduce the issue with this little snippet:
```
variable "enabled" {
  default = true
}

resource "random_string" "rnd" {
  count   = var.enabled ? 1 : 0
  length  = 4
}

output "project_id" {
#  value       = var.enabled ? coalesce(random_string.rnd.*.result...) : "xxxx"
  value       = var.enabled ? coalesce(flatten([random_string.rnd.*.result])...) : "xxxx"
}
```
tested with terraform 0.12.12 to 0.12.20

tests passed (but the initial tests were passing also, they might not access this output variable)
lint passed
