### PR TITLE
Adding type constraints to variables.

### DIFF
--- a/modules/fabric-net-firewall/README.md
+++ b/modules/fabric-net-firewall/README.md
@@ -72,17 +72,17 @@ module "net-firewall" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| admin\_ranges | IP CIDR ranges that have complete access to all subnets. | list | `<list>` | no |
-| admin\_ranges\_enabled | Enable admin ranges-based rules. | string | `"false"` | no |
+| admin\_ranges | IP CIDR ranges that have complete access to all subnets. | list(string) | `<list>` | no |
+| admin\_ranges\_enabled | Enable admin ranges-based rules. | bool | `"false"` | no |
 | custom\_rules | List of custom rule definitions (refer to variables file for syntax). | object | `<map>` | no |
-| http\_source\_ranges | List of IP CIDR ranges for tag-based HTTP rule, defaults to 0.0.0.0/0. | list | `<list>` | no |
-| https\_source\_ranges | List of IP CIDR ranges for tag-based HTTPS rule, defaults to 0.0.0.0/0. | list | `<list>` | no |
-| internal\_allow | Allow rules for internal ranges. | list | `<list>` | no |
-| internal\_ranges | IP CIDR ranges for intra-VPC rules. | list | `<list>` | no |
-| internal\_ranges\_enabled | Create rules for intra-VPC ranges. | string | `"false"` | no |
+| http\_source\_ranges | List of IP CIDR ranges for tag-based HTTP rule, defaults to 0.0.0.0/0. | list(string) | `<list>` | no |
+| https\_source\_ranges | List of IP CIDR ranges for tag-based HTTPS rule, defaults to 0.0.0.0/0. | list(string) | `<list>` | no |
+| internal\_allow | Allow rules for internal ranges. | object | `<list>` | no |
+| internal\_ranges | IP CIDR ranges for intra-VPC rules. | list(string) | `<list>` | no |
+| internal\_ranges\_enabled | Create rules for intra-VPC ranges. | bool | `"false"` | no |
 | network | Name of the network this set of firewall rules applies to. | string | n/a | yes |
 | project\_id | Project id of the project that holds the network. | string | n/a | yes |
-| ssh\_source\_ranges | List of IP CIDR ranges for tag-based SSH rule, defaults to 0.0.0.0/0. | list | `<list>` | no |
+| ssh\_source\_ranges | List of IP CIDR ranges for tag-based SSH rule, defaults to 0.0.0.0/0. | list(string) | `<list>` | no |
 
 ## Outputs
 

--- a/modules/fabric-net-firewall/variables.tf
+++ b/modules/fabric-net-firewall/variables.tf
@@ -16,24 +16,29 @@
 
 variable "network" {
   description = "Name of the network this set of firewall rules applies to."
+  type        = string
 }
 
 variable "project_id" {
   description = "Project id of the project that holds the network."
+  type        = string
 }
 
 variable "internal_ranges_enabled" {
   description = "Create rules for intra-VPC ranges."
+  type        = bool
   default     = false
 }
 
 variable "internal_ranges" {
   description = "IP CIDR ranges for intra-VPC rules."
+  type        = list(string)
   default     = []
 }
 
 variable "internal_allow" {
   description = "Allow rules for internal ranges."
+  type        = list(string)
   default = [
     {
       protocol = "icmp"
@@ -43,26 +48,31 @@ variable "internal_allow" {
 
 variable "admin_ranges_enabled" {
   description = "Enable admin ranges-based rules."
+  type        = bool
   default     = false
 }
 
 variable "admin_ranges" {
   description = "IP CIDR ranges that have complete access to all subnets."
+  type        = list(string)
   default     = []
 }
 
 variable "ssh_source_ranges" {
   description = "List of IP CIDR ranges for tag-based SSH rule, defaults to 0.0.0.0/0."
+  type        = list(string)
   default     = ["0.0.0.0/0"]
 }
 
 variable "http_source_ranges" {
   description = "List of IP CIDR ranges for tag-based HTTP rule, defaults to 0.0.0.0/0."
+  type        = list(string)
   default     = ["0.0.0.0/0"]
 }
 
 variable "https_source_ranges" {
   description = "List of IP CIDR ranges for tag-based HTTPS rule, defaults to 0.0.0.0/0."
+  type        = list(string)
   default     = ["0.0.0.0/0"]
 }
 

--- a/modules/fabric-net-svpc-access/README.md
+++ b/modules/fabric-net-svpc-access/README.md
@@ -41,13 +41,13 @@ module "net-shared-vpc-access" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | host\_project\_id | Project id of the shared VPC host project. | string | n/a | yes |
-| host\_service\_agent\_role | Assign host service agent role to users in host_service_agent_users variable. | string | `"false"` | no |
-| host\_service\_agent\_users | List of IAM-style users that will be granted the host service agent role on the host project. | list | `<list>` | no |
-| host\_subnet\_regions | List of subnet regions, one per subnet. | list | `<list>` | no |
+| host\_service\_agent\_role | Assign host service agent role to users in host_service_agent_users variable. | bool | `"false"` | no |
+| host\_service\_agent\_users | List of IAM-style users that will be granted the host service agent role on the host project. | list(string) | `<list>` | no |
+| host\_subnet\_regions | List of subnet regions, one per subnet. | list(string) | `<list>` | no |
 | host\_subnet\_users | Map of comma-delimited IAM-style members to which network user roles for subnets will be assigned. | map | `<map>` | no |
-| host\_subnets | List of subnet names on which to grant network user role. | list | `<list>` | no |
+| host\_subnets | List of subnet names on which to grant network user role. | list(string) | `<list>` | no |
 | service\_project\_ids | Ids of the service projects that will be attached to the Shared VPC. | list(string) | n/a | yes |
-| service\_project\_num | Number of service projects that will be attached to the Shared VPC. | string | `"0"` | no |
+| service\_project\_num | Number of service projects that will be attached to the Shared VPC. | number | `"0"` | no |
 
 ## Outputs
 

--- a/modules/fabric-net-svpc-access/variables.tf
+++ b/modules/fabric-net-svpc-access/variables.tf
@@ -22,6 +22,7 @@ variable "host_project_id" {
 
 variable "service_project_num" {
   description = "Number of service projects that will be attached to the Shared VPC."
+  type        = number
   default     = 0
 }
 
@@ -32,25 +33,30 @@ variable "service_project_ids" {
 
 variable "host_subnets" {
   description = "List of subnet names on which to grant network user role."
+  type        = list(string)
   default     = []
 }
 
 variable "host_subnet_regions" {
   description = "List of subnet regions, one per subnet."
+  type        = list(string)
   default     = []
 }
 
 variable "host_subnet_users" {
   description = "Map of comma-delimited IAM-style members to which network user roles for subnets will be assigned."
+  type        = map
   default     = {}
 }
 
 variable "host_service_agent_role" {
   description = "Assign host service agent role to users in host_service_agent_users variable."
+  type        = bool
   default     = false
 }
 
 variable "host_service_agent_users" {
   description = "List of IAM-style users that will be granted the host service agent role on the host project."
+  type        = list(string)
   default     = []
 }

--- a/modules/routes/variables.tf
+++ b/modules/routes/variables.tf
@@ -16,20 +16,23 @@
 
 variable "project_id" {
   description = "The ID of the project where the routes will be created"
+  type        = string
 }
 
 variable "network_name" {
   description = "The name of the network where routes will be created"
+  type        = string
 }
 
 variable "routes" {
-  type        = list(map(string))
   description = "List of routes being created in this VPC"
+  type        = list(map(string))
   default     = []
 }
 
 variable "delete_default_internet_gateway_routes" {
   description = "If set, ensure that all routes within the network specified whose names begin with 'default-route' and with a next hop of 'default-internet-gateway' are deleted"
+  type        = string
   default     = "false"
 }
 

--- a/modules/subnets/variables.tf
+++ b/modules/subnets/variables.tf
@@ -16,19 +16,21 @@
 
 variable "project_id" {
   description = "The ID of the project where subnets will be created"
+  type        = string
 }
 
 variable "network_name" {
   description = "The name of the network where subnets will be created"
+  type        = string
 }
 
 variable "subnets" {
-  type        = list(map(string))
   description = "The list of subnets being created"
+  type        = list(map(string))
 }
 
 variable "secondary_ranges" {
-  type        = map(list(object({ range_name = string, ip_cidr_range = string })))
   description = "Secondary ranges that will be used in some of the subnets"
+  type        = map(list(object({ range_name = string, ip_cidr_range = string })))
   default     = {}
 }

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -16,32 +16,34 @@
 
 variable "project_id" {
   description = "The ID of the project where this VPC will be created"
+  type        = string
 }
 
 variable "network_name" {
   description = "The name of the network being created"
+  type        = string
 }
 
 variable "routing_mode" {
+  description = "The network routing mode (default 'GLOBAL')"
   type        = string
   default     = "GLOBAL"
-  description = "The network routing mode (default 'GLOBAL')"
 }
 
 variable "shared_vpc_host" {
-  type        = bool
   description = "Makes this project a Shared VPC host if 'true' (default 'false')"
+  type        = bool
   default     = false
 }
 
 variable "description" {
-  type        = string
   description = "An optional description of this resource. The resource must be recreated to modify this field."
+  type        = string
   default     = ""
 }
 
 variable "auto_create_subnetworks" {
-  type        = bool
   description = "When set to true, the network is created in 'auto subnet mode' and it will create a subnet for each region automatically across the 10.128.0.0/9 address range. When set to false, the network is created in 'custom subnet mode' so the user can explicitly connect subnetwork resources."
+  type        = bool
   default     = false
 }


### PR DESCRIPTION
For best practices and for terragrunt users [0]. Type constrains should be added [1]. Without specifying these constraints, applying a terragrunt plan/apply results in type errors [2], depending on the type constraints.

In terragrunt, "values are being passed in with environment variables and json, the type information is lost when crossing the boundary between Terragrunt and Terraform. You must specify the proper type constraint on the variable in Terraform in order for Terraform to process the inputs to the right type" [3]. Similar PR [4]

tl;dr lists and maps currently do not work with terragrunt because type constraints are not explicitly set.

[0] https://github.com/gruntwork-io/terragrunt
[1] https://www.terraform.io/docs/configuration/variables.html#type-constraints
[2] Invalid value for "inputMap" parameter: lookup() requires a map as the first
argument.
[3] https://terragrunt.gruntwork.io/docs/reference/config-blocks-and-attributes/#inputs
[4] https://github.com/terraform-google-modules/terraform-google-cloud-storage/pull/43