### PR TITLE
add network output

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description |
 |------|-------------|
+| network | The created network |
 | network\_name | The name of the VPC being created |
 | network\_self\_link | The URI of the VPC being created |
 | project\_id | VPC project id |

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,6 +14,16 @@
  * limitations under the License.
  */
 
+output "network" {
+  value       = module.vpc
+  description = "The created network"
+}
+
+output "subnets" {
+  value       = module.subnets.subnets
+  description = "A map with keys of form subnet_region/subnet_name and values being the outputs of the google_compute_subnetwork resources used to create corresponding subnets."
+}
+
 output "network_name" {
   value       = module.vpc.network_name
   description = "The name of the VPC being created"
@@ -67,9 +77,4 @@ output "subnets_secondary_ranges" {
 output "route_names" {
   value       = [for route in module.routes.routes : route.name]
   description = "The route names associated with this VPC"
-}
-
-output "subnets" {
-  value       = module.subnets.subnets
-  description = "A map with keys of form subnet_region/subnet_name and values being the outputs of the google_compute_subnetwork resources used to create corresponding subnets."
 }


### PR DESCRIPTION
Currently there is no way to get the network ID. Add the entire network as an output so users can use it however they need.