### PR TITLE
helpers: Change attributes to attributes_flat

### DIFF
--- a/helpers/migrate.py
+++ b/helpers/migrate.py
@@ -304,7 +304,7 @@ class TerraformState:
         else:
             state_resource = state_resource_list[0]["instances"]
 
-        return state_resource[0]["attributes"][key]
+        return state_resource[0]["attributes_flat"][key]
 
 
 def group_by_module(resources):


### PR DESCRIPTION
When running the migrate script, it encountered a KeyError `attributes` not found. I looked at the `terraform state pull` output, and saw there was an `attributes_flat` that likely changed in newer Terraform versions. I'm supplying this change to reflect that API change.