### PR TITLE
Resolve Invalid index error on shared vpc destroy

### DIFF
--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -30,6 +30,6 @@ output "network_self_link" {
 }
 
 output "project_id" {
-  value       = var.shared_vpc_host ? google_compute_shared_vpc_host_project.shared_vpc_host.*.project[0] : google_compute_network.network.project
+  value       = var.shared_vpc_host && length(google_compute_shared_vpc_host_project.shared_vpc_host) > 0 ? google_compute_shared_vpc_host_project.shared_vpc_host.*.project[0] : google_compute_network.network.project
   description = "VPC project id"
 }


### PR DESCRIPTION
Checks that google_compute_shared_vpc_host_project.shared_vpc_host
is not empty before attempting to return the value. Avoids the error
"google_compute_shared_vpc_host_project.shared_vpc_host is empty tuple
The given key does not identify an element in this collection value."

Fixes #176 

This error seems to be caused by terraform deleting the google_compute_shared_vpc_host_project.shared_vpc_host object, but then the outputs being triggered attempts to return an empty value since that object no longer exists. This fix adds a check that the shared_vpc_host values must be true and the google_compute_shared_vpc_host_project.shared_vpc_host value can not be empty for it to return the value stored. 