### PR TITLE
fix: Add variable types for all variables

### DIFF
--- a/modules/fabric-net-firewall/variables.tf
+++ b/modules/fabric-net-firewall/variables.tf
@@ -16,53 +16,67 @@
 
 variable "network" {
   description = "Name of the network this set of firewall rules applies to."
+  type        = string
 }
 
 variable "project_id" {
   description = "Project id of the project that holds the network."
+  type        = string
 }
 
 variable "internal_ranges_enabled" {
   description = "Create rules for intra-VPC ranges."
+  type        = bool
   default     = false
 }
 
 variable "internal_ranges" {
   description = "IP CIDR ranges for intra-VPC rules."
+  type        = list(string)
   default     = []
 }
 
 variable "internal_allow" {
   description = "Allow rules for internal ranges."
+  type = list(object({
+    protocol = string
+    ports    = list(string)
+  }))
   default = [
     {
       protocol = "icmp"
+      ports    = []
     },
   ]
 }
 
 variable "admin_ranges_enabled" {
   description = "Enable admin ranges-based rules."
+  type        = bool
   default     = false
 }
 
 variable "admin_ranges" {
   description = "IP CIDR ranges that have complete access to all subnets."
+  type        = list(string)
   default     = []
 }
 
 variable "ssh_source_ranges" {
   description = "List of IP CIDR ranges for tag-based SSH rule, defaults to 0.0.0.0/0."
+  type        = list(string)
   default     = ["0.0.0.0/0"]
 }
 
 variable "http_source_ranges" {
   description = "List of IP CIDR ranges for tag-based HTTP rule, defaults to 0.0.0.0/0."
+  type        = list(string)
   default     = ["0.0.0.0/0"]
 }
 
 variable "https_source_ranges" {
   description = "List of IP CIDR ranges for tag-based HTTPS rule, defaults to 0.0.0.0/0."
+  type        = list(string)
   default     = ["0.0.0.0/0"]
 }
 


### PR DESCRIPTION
It's a good practice and terragrunt does not work properly without it.