### PR TITLE
Allow to pass target_tags to the default firewalls

### DIFF
--- a/modules/fabric-net-firewall/README.md
+++ b/modules/fabric-net-firewall/README.md
@@ -29,9 +29,9 @@ The resources created/managed by this module are:
 
 - one optional ingress rule from internal CIDR ranges, only allowing ICMP by default
 - one optional ingress rule from admin CIDR ranges, allowing all protocols on all ports
-- one optional ingress rule for SSH on network tag `ssh`
-- one optional ingress rule for HTTP on network tag `http-server`
-- one optional ingress rule for HTTPS on network tag `https-server`
+- one optional ingress rule for SSH on network tag `ssh` by default
+- one optional ingress rule for HTTP on network tag `http-server` by default
+- one optional ingress rule for HTTPS on network tag `https-server` by default
 - one or more optional custom rules
 
 
@@ -46,6 +46,7 @@ module "net-firewall" {
   network                 = "my-vpc"
   internal_ranges_enabled = true
   internal_ranges         = ["10.0.0.0/0"]
+  internal_target_tags    = ["internal"]
   custom_rules = {
     ingress-sample = {
       description          = "Dummy sample ingress rule, tag-based."
@@ -76,13 +77,17 @@ module "net-firewall" {
 | admin\_ranges\_enabled | Enable admin ranges-based rules. | string | `"false"` | no |
 | custom\_rules | List of custom rule definitions (refer to variables file for syntax). | object | `<map>` | no |
 | http\_source\_ranges | List of IP CIDR ranges for tag-based HTTP rule, defaults to 0.0.0.0/0. | list | `<list>` | no |
+| http\_target\_tags | List of target tags for tag-based HTTP rule, defaults to http-server. | list | `<list>` | no |
 | https\_source\_ranges | List of IP CIDR ranges for tag-based HTTPS rule, defaults to 0.0.0.0/0. | list | `<list>` | no |
+| https\_target\_tags | List of target tags for tag-based HTTPS rule, defaults to https-server. | list | `<list>` | no |
 | internal\_allow | Allow rules for internal ranges. | list | `<list>` | no |
 | internal\_ranges | IP CIDR ranges for intra-VPC rules. | list | `<list>` | no |
 | internal\_ranges\_enabled | Create rules for intra-VPC ranges. | string | `"false"` | no |
+| internal\_target\_tags | List of target tags for intra-VPC rules. | list | `<list>` | no |
 | network | Name of the network this set of firewall rules applies to. | string | n/a | yes |
 | project\_id | Project id of the project that holds the network. | string | n/a | yes |
 | ssh\_source\_ranges | List of IP CIDR ranges for tag-based SSH rule, defaults to 0.0.0.0/0. | list | `<list>` | no |
+| ssh\_target\_tags | List of target tags for tag-based SSH rule, defaults to ssh. | list | `<list>` | no |
 
 ## Outputs
 

--- a/modules/fabric-net-firewall/main.tf
+++ b/modules/fabric-net-firewall/main.tf
@@ -25,6 +25,7 @@ resource "google_compute_firewall" "allow-internal" {
   network       = var.network
   project       = var.project_id
   source_ranges = var.internal_ranges
+  target_tags   = var.internal_target_tags
 
   dynamic "allow" {
     for_each = [for rule in var.internal_allow :
@@ -38,12 +39,7 @@ resource "google_compute_firewall" "allow-internal" {
       ports    = allow.value.ports
     }
   }
-
 }
-
-
-
-
 
 resource "google_compute_firewall" "allow-admins" {
   count         = var.admin_ranges_enabled == true ? 1 : 0
@@ -77,7 +73,7 @@ resource "google_compute_firewall" "allow-tag-ssh" {
   network       = var.network
   project       = var.project_id
   source_ranges = var.ssh_source_ranges
-  target_tags   = ["ssh"]
+  target_tags   = var.ssh_target_tags
 
   allow {
     protocol = "tcp"
@@ -92,7 +88,7 @@ resource "google_compute_firewall" "allow-tag-http" {
   network       = var.network
   project       = var.project_id
   source_ranges = var.http_source_ranges
-  target_tags   = ["http-server"]
+  target_tags   = var.http_target_tags
 
   allow {
     protocol = "tcp"
@@ -107,7 +103,7 @@ resource "google_compute_firewall" "allow-tag-https" {
   network       = var.network
   project       = var.project_id
   source_ranges = var.https_source_ranges
-  target_tags   = ["https-server"]
+  target_tags   = var.https_target_tags
 
   allow {
     protocol = "tcp"

--- a/modules/fabric-net-firewall/variables.tf
+++ b/modules/fabric-net-firewall/variables.tf
@@ -32,6 +32,11 @@ variable "internal_ranges" {
   default     = []
 }
 
+variable "internal_target_tags" {
+  description = "List of target tags for intra-VPC rules."
+  default     = []
+}
+
 variable "internal_allow" {
   description = "Allow rules for internal ranges."
   default = [
@@ -56,14 +61,29 @@ variable "ssh_source_ranges" {
   default     = ["0.0.0.0/0"]
 }
 
+variable "ssh_target_tags" {
+  description = "List of target tags for tag-based SSH rule, defaults to ssh."
+  default     = ["ssh"]
+}
+
 variable "http_source_ranges" {
   description = "List of IP CIDR ranges for tag-based HTTP rule, defaults to 0.0.0.0/0."
   default     = ["0.0.0.0/0"]
 }
 
+variable "http_target_tags" {
+  description = "List of target tags for tag-based HTTP rule, defaults to http-server."
+  default     = ["http-server"]
+}
+
 variable "https_source_ranges" {
   description = "List of IP CIDR ranges for tag-based HTTPS rule, defaults to 0.0.0.0/0."
   default     = ["0.0.0.0/0"]
+}
+
+variable "https_target_tags" {
+  description = "List of target tags for tag-based HTTPS rule, defaults to https-server."
+  default     = ["https-server"]
 }
 
 variable "custom_rules" {


### PR DESCRIPTION
This PR adds the ability to specify the target_tags attribute for the default firewalls, rather than having them hardcoded within the code