### PR TITLE
chore: relax tf version to allow 0.13 

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,6 +16,7 @@
 driver:
   name: "terraform"
   command_timeout: 1800
+  verify_version: false
 
 provisioner:
   name: "terraform"

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.6.0
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -166,4 +166,4 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.6.0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0'

--- a/examples/delete_default_gateway_routes/versions.tf
+++ b/examples/delete_default_gateway_routes/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/ilb_routing/versions.tf
+++ b/examples/ilb_routing/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/multi_vpc/versions.tf
+++ b/examples/multi_vpc/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/secondary_ranges/versions.tf
+++ b/examples/secondary_ranges/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/simple_project/versions.tf
+++ b/examples/simple_project/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/simple_project_with_regional_network/versions.tf
+++ b/examples/simple_project_with_regional_network/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/submodule_firewall/versions.tf
+++ b/examples/submodule_firewall/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/submodule_network_peering/versions.tf
+++ b/examples/submodule_network_peering/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/submodule_svpc_access/versions.tf
+++ b/examples/submodule_svpc_access/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/modules/fabric-net-firewall/versions.tf
+++ b/modules/fabric-net-firewall/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google = "<4.0,>= 2.12"
   }

--- a/modules/fabric-net-svpc-access/versions.tf
+++ b/modules/fabric-net-svpc-access/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google = "<4.0,>= 2.12"
   }

--- a/modules/network-peering/versions.tf
+++ b/modules/network-peering/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google = "<4.0,>= 2.12"
   }

--- a/modules/routes-beta/versions.tf
+++ b/modules/routes-beta/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google-beta = "~> 2.19.0"
   }

--- a/modules/routes/versions.tf
+++ b/modules/routes/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google = "<4.0,>= 2.12"
   }

--- a/modules/subnets-beta/versions.tf
+++ b/modules/subnets-beta/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google-beta = ">= 2.19.0, <4.0.0"
   }

--- a/modules/subnets/versions.tf
+++ b/modules/subnets/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google = "<4.0,>= 2.12"
   }

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google = "<4.0,>= 2.12"
   }

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }
 
 provider "google" {

--- a/versions.tf
+++ b/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google = "<4.0,>= 2.12"
   }


### PR DESCRIPTION
fixes #196 
- relax version constraint to allow usage with 0.13
- Kitchen tests [run with `v0.13.0-rc1`](https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/commit/88017ad3bc0d40473ac3d94546660328aeee878d) 
   - All tests passed
- module `for_each` spot checked, have not tested `depends_on`, but based on other modules I expect it to work