### PR TITLE
FIX: Value types for most of fabric-net-firewall module variables

### DIFF
--- a/examples/submodule_firewall/main.tf
+++ b/examples/submodule_firewall/main.tf
@@ -128,7 +128,8 @@ module "test-firewall-submodule" {
 
   internal_allow = [
     {
-      protocol = "icmp"
+      protocol = "icmp",
+      ports    = [] # all ports
     },
     {
       protocol = "tcp",
@@ -136,7 +137,7 @@ module "test-firewall-submodule" {
     },
     {
       protocol = "udp"
-      # all ports will be opened if `ports` key isn't specified
+      ports    = null # all ports
     },
   ]
   custom_rules = local.custom_rules

--- a/modules/fabric-net-firewall/README.md
+++ b/modules/fabric-net-firewall/README.md
@@ -73,21 +73,21 @@ module "net-firewall" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| admin\_ranges | IP CIDR ranges that have complete access to all subnets. | list | `<list>` | no |
-| admin\_ranges\_enabled | Enable admin ranges-based rules. | string | `"false"` | no |
+| admin\_ranges | IP CIDR ranges that have complete access to all subnets. | list(string) | `<list>` | no |
+| admin\_ranges\_enabled | Enable admin ranges-based rules. | bool | `"false"` | no |
 | custom\_rules | List of custom rule definitions (refer to variables file for syntax). | object | `<map>` | no |
-| http\_source\_ranges | List of IP CIDR ranges for tag-based HTTP rule, defaults to 0.0.0.0/0. | list | `<list>` | no |
-| http\_target\_tags | List of target tags for tag-based HTTP rule, defaults to http-server. | list | `<list>` | no |
-| https\_source\_ranges | List of IP CIDR ranges for tag-based HTTPS rule, defaults to 0.0.0.0/0. | list | `<list>` | no |
-| https\_target\_tags | List of target tags for tag-based HTTPS rule, defaults to https-server. | list | `<list>` | no |
-| internal\_allow | Allow rules for internal ranges. | list | `<list>` | no |
-| internal\_ranges | IP CIDR ranges for intra-VPC rules. | list | `<list>` | no |
-| internal\_ranges\_enabled | Create rules for intra-VPC ranges. | string | `"false"` | no |
-| internal\_target\_tags | List of target tags for intra-VPC rules. | list | `<list>` | no |
+| http\_source\_ranges | List of IP CIDR ranges for tag-based HTTP rule, defaults to 0.0.0.0/0. | list(string) | `<list>` | no |
+| http\_target\_tags | List of target tags for tag-based HTTP rule, defaults to http-server. | list(string) | `<list>` | no |
+| https\_source\_ranges | List of IP CIDR ranges for tag-based HTTPS rule, defaults to 0.0.0.0/0. | list(string) | `<list>` | no |
+| https\_target\_tags | List of target tags for tag-based HTTPS rule, defaults to https-server. | list(string) | `<list>` | no |
+| internal\_allow | Allow rules for internal ranges. | object | `<list>` | no |
+| internal\_ranges | IP CIDR ranges for intra-VPC rules. | list(string) | `<list>` | no |
+| internal\_ranges\_enabled | Create rules for intra-VPC ranges. | bool | `"false"` | no |
+| internal\_target\_tags | List of target tags for intra-VPC rules. | list(string) | `<list>` | no |
 | network | Name of the network this set of firewall rules applies to. | string | n/a | yes |
 | project\_id | Project id of the project that holds the network. | string | n/a | yes |
-| ssh\_source\_ranges | List of IP CIDR ranges for tag-based SSH rule, defaults to 0.0.0.0/0. | list | `<list>` | no |
-| ssh\_target\_tags | List of target tags for tag-based SSH rule, defaults to ssh. | list | `<list>` | no |
+| ssh\_source\_ranges | List of IP CIDR ranges for tag-based SSH rule, defaults to 0.0.0.0/0. | list(string) | `<list>` | no |
+| ssh\_target\_tags | List of target tags for tag-based SSH rule, defaults to ssh. | list(string) | `<list>` | no |
 
 ## Outputs
 

--- a/modules/fabric-net-firewall/main.tf
+++ b/modules/fabric-net-firewall/main.tf
@@ -30,8 +30,8 @@ resource "google_compute_firewall" "allow-internal" {
   dynamic "allow" {
     for_each = [for rule in var.internal_allow :
       {
-        protocol = lookup(rule, "protocol", null)
-        ports    = lookup(rule, "ports", null)
+        protocol = rule.protocol
+        ports    = rule.ports
       }
     ]
     content {

--- a/modules/fabric-net-firewall/variables.tf
+++ b/modules/fabric-net-firewall/variables.tf
@@ -24,65 +24,81 @@ variable "project_id" {
 
 variable "internal_ranges_enabled" {
   description = "Create rules for intra-VPC ranges."
+  type        = bool
   default     = false
 }
 
 variable "internal_ranges" {
   description = "IP CIDR ranges for intra-VPC rules."
+  type        = list(string)
   default     = []
 }
 
 variable "internal_target_tags" {
   description = "List of target tags for intra-VPC rules."
+  type        = list(string)
   default     = []
 }
 
 variable "internal_allow" {
   description = "Allow rules for internal ranges."
+  type = list(object({
+    protocol = string
+    ports    = list(string)
+  }))
   default = [
     {
       protocol = "icmp"
-    },
+      ports    = []
+    }
   ]
 }
 
 variable "admin_ranges_enabled" {
   description = "Enable admin ranges-based rules."
+  type        = bool
   default     = false
 }
 
 variable "admin_ranges" {
   description = "IP CIDR ranges that have complete access to all subnets."
+  type        = list(string)
   default     = []
 }
 
 variable "ssh_source_ranges" {
   description = "List of IP CIDR ranges for tag-based SSH rule, defaults to 0.0.0.0/0."
+  type        = list(string)
   default     = ["0.0.0.0/0"]
 }
 
 variable "ssh_target_tags" {
   description = "List of target tags for tag-based SSH rule, defaults to ssh."
+  type        = list(string)
   default     = ["ssh"]
 }
 
 variable "http_source_ranges" {
   description = "List of IP CIDR ranges for tag-based HTTP rule, defaults to 0.0.0.0/0."
+  type        = list(string)
   default     = ["0.0.0.0/0"]
 }
 
 variable "http_target_tags" {
   description = "List of target tags for tag-based HTTP rule, defaults to http-server."
+  type        = list(string)
   default     = ["http-server"]
 }
 
 variable "https_source_ranges" {
   description = "List of IP CIDR ranges for tag-based HTTPS rule, defaults to 0.0.0.0/0."
+  type        = list(string)
   default     = ["0.0.0.0/0"]
 }
 
 variable "https_target_tags" {
   description = "List of target tags for tag-based HTTPS rule, defaults to https-server."
+  type        = list(string)
   default     = ["https-server"]
 }
 


### PR DESCRIPTION
This PR sets explicit types for all variables.

This relates to #158 and fixes #157 

Team work with: @rdavidr @silvaom @lucrevillegas

