### PR TITLE
Setting default values for Flow log config

### DIFF
--- a/modules/subnets-beta/main.tf
+++ b/modules/subnets-beta/main.tf
@@ -34,9 +34,9 @@ resource "google_compute_subnetwork" "subnetwork" {
   private_ip_google_access = lookup(each.value, "subnet_private_access", "false")
   dynamic "log_config" {
     for_each = lookup(each.value, "subnet_flow_logs", false) ? [{
-      aggregation_interval = lookup(each.value, "subnet_flow_logs_interval", null)
-      flow_sampling        = lookup(each.value, "subnet_flow_logs_sampling", null)
-      metadata             = lookup(each.value, "subnet_flow_logs_metadata", null)
+      aggregation_interval = lookup(each.value, "subnet_flow_logs_interval", "INTERVAL_5_SEC")
+      flow_sampling        = lookup(each.value, "subnet_flow_logs_sampling", "0.5")
+      metadata             = lookup(each.value, "subnet_flow_logs_metadata", "INCLUDE_ALL_METADATA")
     }] : []
     content {
       aggregation_interval = log_config.value.aggregation_interval


### PR DESCRIPTION
This PR is setting default values for the Flow log config block the same way like it's set in the [`subnets`](https://github.com/terraform-google-modules/terraform-google-network/tree/master/modules/subnets/main.tf#L36-L38) sub-module. The reason for this to be set is that if the `subnet_flow_logs` is set to `true`, one of the three attributes must be set otherwise it fails with this error:

```
Error: AtLeastOne

  on .terraform/modules/vpc.subnets/modules/subnets-beta/main.tf line 28, in resource "google_compute_subnetwork" "subnetwork":
  28: resource "google_compute_subnetwork" "subnetwork" {

"log_config.0.filter_expr": one of
`log_config.0.aggregation_interval,log_config.0.filter_expr,log_config.0.flow_sampling,log_config.0.metadata`
must be specified
```