### PR TITLE
Quoted references are deprecated

### DIFF
--- a/modules/network-peering/main.tf
+++ b/modules/network-peering/main.tf
@@ -27,7 +27,7 @@ resource "google_compute_network_peering" "local_network_peering" {
   export_custom_routes = var.export_local_custom_routes
   import_custom_routes = var.export_peer_custom_routes
 
-  depends_on = ["null_resource.module_depends_on"]
+  depends_on = [null_resource.module_depends_on]
 }
 
 resource "google_compute_network_peering" "peer_network_peering" {
@@ -38,7 +38,7 @@ resource "google_compute_network_peering" "peer_network_peering" {
   export_custom_routes = var.export_peer_custom_routes
   import_custom_routes = var.export_local_custom_routes
 
-  depends_on = ["null_resource.module_depends_on", "google_compute_network_peering.local_network_peering"]
+  depends_on = [null_resource.module_depends_on, google_compute_network_peering.local_network_peering]
 }
 
 resource "null_resource" "module_depends_on" {
@@ -48,5 +48,5 @@ resource "null_resource" "module_depends_on" {
 }
 
 resource "null_resource" "complete" {
-  depends_on = ["google_compute_network_peering.local_network_peering", "google_compute_network_peering.peer_network_peering"]
+  depends_on = [google_compute_network_peering.local_network_peering, google_compute_network_peering.peer_network_peering]
 }


### PR DESCRIPTION
This PR is removing quotes around references to prevent the following warning message:

```
Warning: Quoted references are deprecated

  on .terraform/modules/vpc.peering/modules/network-peering/main.tf line 30, in resource "google_compute_network_peering" "local_network_peering":
  30:   depends_on = ["null_resource.module_depends_on"]

In this context, references are expected literally rather than in quotes.
Terraform 0.11 and earlier required quotes, but quoted references are now
deprecated and will be removed in a future version of Terraform. Remove the
quotes surrounding this reference to silence this warning.

(and 4 more similar warnings elsewhere)
```