### PR TITLE
Renaming deprecated attribute

### DIFF
--- a/modules/fabric-net-firewall/main.tf
+++ b/modules/fabric-net-firewall/main.tf
@@ -131,7 +131,15 @@ resource "google_compute_firewall" "custom" {
   target_service_accounts = each.value.use_service_accounts ? each.value.targets : null
   disabled                = lookup(each.value.extra_attributes, "disabled", false)
   priority                = lookup(each.value.extra_attributes, "priority", 1000)
-  enable_logging          = lookup(each.value.extra_attributes, "enable_logging", null)
+
+  dynamic "log_config" {
+    for_each = lookup(each.value, "flow_logs", false) ? [{
+      metadata = lookup(each.value, "flow_logs_metadata", "INCLUDE_ALL_METADATA")
+    }] : []
+    content {
+      metadata = log_config.value.metadata
+    }
+  }
 
   dynamic "allow" {
     for_each = [for rule in each.value.rules : rule if each.value.action == "allow"]


### PR DESCRIPTION
This PR is renaming attribute `enable_logging` to `log_config` in order to prevent the following warning:

```
Warning: Attribute is deprecated

  on .terraform/modules/vpc.peering_fw_dev_mgmt/modules/fabric-net-firewall/main.tf line 134, in resource "google_compute_firewall" "custom":
 134:   enable_logging          = lookup(each.value.extra_attributes, "enable_logging", null)

Deprecated in favor of log_config
```