### PR TITLE
enable_logging is deprecated

### DIFF
--- a/modules/fabric-net-firewall/main.tf
+++ b/modules/fabric-net-firewall/main.tf
@@ -131,7 +131,9 @@ resource "google_compute_firewall" "custom" {
   target_service_accounts = each.value.use_service_accounts ? each.value.targets : null
   disabled                = lookup(each.value.extra_attributes, "disabled", false)
   priority                = lookup(each.value.extra_attributes, "priority", 1000)
-  enable_logging          = lookup(each.value.extra_attributes, "enable_logging", null)
+  log_config {
+    metadata = lookup(each.value.extra_attributes, "log_config", "EXCLUDE_ALL_METADATA")
+  }
 
   dynamic "allow" {
     for_each = [for rule in each.value.rules : rule if each.value.action == "allow"]


### PR DESCRIPTION
In resource "google_compute_firewall" "custom":
enable_logging          = lookup(each.value.extra_attributes, "enable_logging", null)

Deprecated in favor of log_config