### PR TITLE
Support custom MTU on VPCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Then perform the following commands on the root folder:
 | auto\_create\_subnetworks | When set to true, the network is created in 'auto subnet mode' and it will create a subnet for each region automatically across the 10.128.0.0/9 address range. When set to false, the network is created in 'custom subnet mode' so the user can explicitly connect subnetwork resources. | `bool` | `false` | no |
 | delete\_default\_internet\_gateway\_routes | If set, ensure that all routes within the network specified whose names begin with 'default-route' and with a next hop of 'default-internet-gateway' are deleted | `bool` | `false` | no |
 | description | An optional description of this resource. The resource must be recreated to modify this field. | `string` | `""` | no |
+| mtu | The network MTU (default '1460'). Must be a value between 1460 and 1500 inclusive. | `number` | `1460` | no |
 | network\_name | The name of the network being created | `any` | n/a | yes |
 | project\_id | The ID of the project where this VPC will be created | `any` | n/a | yes |
 | routes | List of routes being created in this VPC | `list(map(string))` | `[]` | no |

--- a/examples/delete_default_gateway_routes/main.tf
+++ b/examples/delete_default_gateway_routes/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.45.0"
 }
 
 provider "null" {

--- a/examples/ilb_routing/main.tf
+++ b/examples/ilb_routing/main.tf
@@ -15,11 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.19.0"
-}
-
-provider "google-beta" {
-  version = "~> 2.19.0"
+  version = "~> 3.45.0"
 }
 
 provider "null" {

--- a/examples/multi_vpc/main.tf
+++ b/examples/multi_vpc/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.45.0"
 }
 
 provider "null" {

--- a/examples/secondary_ranges/main.tf
+++ b/examples/secondary_ranges/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.45.0"
 }
 
 provider "null" {

--- a/examples/simple_project/main.tf
+++ b/examples/simple_project/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.45.0"
 }
 
 provider "null" {

--- a/examples/simple_project_with_regional_network/main.tf
+++ b/examples/simple_project_with_regional_network/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.45.0"
 }
 
 provider "null" {

--- a/examples/submodule_firewall/main.tf
+++ b/examples/submodule_firewall/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.45.0"
 }
 
 provider "null" {

--- a/examples/submodule_network_peering/main.tf
+++ b/examples/submodule_network_peering/main.tf
@@ -15,11 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.3.0"
-}
-
-provider "google-beta" {
-  version = "~> 3.3.0"
+  version = "~> 3.45.0"
 }
 
 provider "null" {

--- a/examples/submodule_svpc_access/main.tf
+++ b/examples/submodule_svpc_access/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 3.3.0"
+  version = "~> 3.45.0"
 }
 
 provider "null" {

--- a/main.tf
+++ b/main.tf
@@ -26,6 +26,7 @@ module "vpc" {
   description                            = var.description
   shared_vpc_host                        = var.shared_vpc_host
   delete_default_internet_gateway_routes = var.delete_default_internet_gateway_routes
+  mtu                                    = var.mtu
 }
 
 /******************************************

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -31,6 +31,7 @@ module "vpc" {
 | auto\_create\_subnetworks | When set to true, the network is created in 'auto subnet mode' and it will create a subnet for each region automatically across the 10.128.0.0/9 address range. When set to false, the network is created in 'custom subnet mode' so the user can explicitly connect subnetwork resources. | `bool` | `false` | no |
 | delete\_default\_internet\_gateway\_routes | If set, ensure that all routes within the network specified whose names begin with 'default-route' and with a next hop of 'default-internet-gateway' are deleted | `bool` | `false` | no |
 | description | An optional description of this resource. The resource must be recreated to modify this field. | `string` | `""` | no |
+| mtu | The network MTU (default '1460'). Must be a value between 1460 and 1500 inclusive. | `number` | `1460` | no |
 | network\_name | The name of the network being created | `any` | n/a | yes |
 | project\_id | The ID of the project where this VPC will be created | `any` | n/a | yes |
 | routing\_mode | The network routing mode (default 'GLOBAL') | `string` | `"GLOBAL"` | no |

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -24,6 +24,7 @@ resource "google_compute_network" "network" {
   project                         = var.project_id
   description                     = var.description
   delete_default_routes_on_create = var.delete_default_internet_gateway_routes
+  mtu                             = var.mtu
 }
 
 /******************************************

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -51,3 +51,9 @@ variable "delete_default_internet_gateway_routes" {
   description = "If set, ensure that all routes within the network specified whose names begin with 'default-route' and with a next hop of 'default-internet-gateway' are deleted"
   default     = false
 }
+
+variable "mtu" {
+  type        = number
+  description = "The network MTU (default '1460'). Must be a value between 1460 and 1500 inclusive."
+  default     = 1460
+}

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -17,6 +17,6 @@
 terraform {
   required_version = ">=0.12.6"
   required_providers {
-    google = "<4.0,>= 2.12"
+    google = "<4.0,>= 3.45"
   }
 }

--- a/test/integration/simple_project/controls/gcloud.rb
+++ b/test/integration/simple_project/controls/gcloud.rb
@@ -57,7 +57,8 @@ control "gcloud" do
           "aggregationInterval" => "INTERVAL_5_SEC",
           "enable" => true,
           "flowSampling" => 0.5,
-          "metadata" => "INCLUDE_ALL_METADATA"
+          "metadata" => "INCLUDE_ALL_METADATA",
+          "filterExpr" => "true"
         }
       )
     end
@@ -81,7 +82,8 @@ control "gcloud" do
           "aggregationInterval" => "INTERVAL_10_MIN",
           "enable" => true,
           "flowSampling" => 0.7,
-          "metadata" => "INCLUDE_ALL_METADATA"
+          "metadata" => "INCLUDE_ALL_METADATA",
+          "filterExpr" => "true"
         }
       )
     end

--- a/variables.tf
+++ b/variables.tf
@@ -69,3 +69,9 @@ variable "auto_create_subnetworks" {
   description = "When set to true, the network is created in 'auto subnet mode' and it will create a subnet for each region automatically across the 10.128.0.0/9 address range. When set to false, the network is created in 'custom subnet mode' so the user can explicitly connect subnetwork resources."
   default     = false
 }
+
+variable "mtu" {
+  type        = number
+  description = "The network MTU (default '1460'). Must be a value between 1460 and 1500 inclusive."
+  default     = 1460
+}


### PR DESCRIPTION
This is a potential update to address feature request #220. It adds an `mtu` variable to root and vpc modules that will set MTU on `google_compute_network` resource.

The update has been tested in a few non-production VPCs without any problems yet.

*Note:* MTU suport has a dependency on release [3.45.0](https://github.com/hashicorp/terraform-provider-google/releases/tag/v3.45.0) of google provider.