### PR TITLE
Set default value of MTU to 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Then perform the following commands on the root folder:
 | auto\_create\_subnetworks | When set to true, the network is created in 'auto subnet mode' and it will create a subnet for each region automatically across the 10.128.0.0/9 address range. When set to false, the network is created in 'custom subnet mode' so the user can explicitly connect subnetwork resources. | `bool` | `false` | no |
 | delete\_default\_internet\_gateway\_routes | If set, ensure that all routes within the network specified whose names begin with 'default-route' and with a next hop of 'default-internet-gateway' are deleted | `bool` | `false` | no |
 | description | An optional description of this resource. The resource must be recreated to modify this field. | `string` | `""` | no |
-| mtu | The network MTU (default '1460'). Must be a value between 1460 and 1500 inclusive. | `number` | `1460` | no |
+| mtu | The network MTU. Must be a value between 1460 and 1500 inclusive. If set to 0 (meaning MTU is unset), the network will default to 1460 automatically. | `number` | `0` | no |
 | network\_name | The name of the network being created | `any` | n/a | yes |
 | project\_id | The ID of the project where this VPC will be created | `any` | n/a | yes |
 | routes | List of routes being created in this VPC | `list(map(string))` | `[]` | no |

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -31,7 +31,7 @@ module "vpc" {
 | auto\_create\_subnetworks | When set to true, the network is created in 'auto subnet mode' and it will create a subnet for each region automatically across the 10.128.0.0/9 address range. When set to false, the network is created in 'custom subnet mode' so the user can explicitly connect subnetwork resources. | `bool` | `false` | no |
 | delete\_default\_internet\_gateway\_routes | If set, ensure that all routes within the network specified whose names begin with 'default-route' and with a next hop of 'default-internet-gateway' are deleted | `bool` | `false` | no |
 | description | An optional description of this resource. The resource must be recreated to modify this field. | `string` | `""` | no |
-| mtu | The network MTU (default '1460'). Must be a value between 1460 and 1500 inclusive. | `number` | `1460` | no |
+| mtu | The network MTU. Must be a value between 1460 and 1500 inclusive. If set to 0 (meaning MTU is unset), the network will default to 1460 automatically. | `number` | `0` | no |
 | network\_name | The name of the network being created | `any` | n/a | yes |
 | project\_id | The ID of the project where this VPC will be created | `any` | n/a | yes |
 | routing\_mode | The network routing mode (default 'GLOBAL') | `string` | `"GLOBAL"` | no |

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -54,6 +54,6 @@ variable "delete_default_internet_gateway_routes" {
 
 variable "mtu" {
   type        = number
-  description = "The network MTU (default '1460'). Must be a value between 1460 and 1500 inclusive."
-  default     = 1460
+  description = "The network MTU. Must be a value between 1460 and 1500 inclusive. If set to 0 (meaning MTU is unset), the network will default to 1460 automatically."
+  default     = 0
 }

--- a/variables.tf
+++ b/variables.tf
@@ -72,6 +72,6 @@ variable "auto_create_subnetworks" {
 
 variable "mtu" {
   type        = number
-  description = "The network MTU (default '1460'). Must be a value between 1460 and 1500 inclusive."
-  default     = 1460
+  description = "The network MTU. Must be a value between 1460 and 1500 inclusive. If set to 0 (meaning MTU is unset), the network will default to 1460 automatically."
+  default     = 0
 }


### PR DESCRIPTION
Recent changes to this module added the MTU parameter which defaults to value `1460`. Unfortunately that breaks the backward compatibility (from the time when the MTU parameter wasn't present) and it forces the network to be rebuilt unless the MTU is set to `0`. From the API point of view this is not necessary as the parameter is [optional](https://github.com/hashicorp/terraform-provider-google/blob/master/google/resource_compute_network.go#L81). Basically, if the MTU is not set, it defaults to 1460 anyway so it's not necessary set it.