### PR TITLE
fix: Set firewall logging for each rule

### DIFF
--- a/examples/submodule_firewall/main.tf
+++ b/examples/submodule_firewall/main.tf
@@ -70,8 +70,10 @@ locals {
       }]
 
       extra_attributes = {
-        disabled = true
-        priority = 95
+        disabled           = true
+        priority           = 95
+        flow_logs          = true
+        flow_logs_metadata = "EXCLUDE_ALL_METADATA"
       }
     }
 
@@ -111,7 +113,8 @@ locals {
         }
       ]
       extra_attributes = {
-        priority = 30
+        priority  = 30
+        flow_logs = true
       }
     }
   }

--- a/modules/fabric-net-firewall/README.md
+++ b/modules/fabric-net-firewall/README.md
@@ -73,20 +73,20 @@ module "net-firewall" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| admin\_ranges | IP CIDR ranges that have complete access to all subnets. | `list` | `[]` | no |
+| admin\_ranges | IP CIDR ranges that have complete access to all subnets. | `list(string)` | `[]` | no |
 | admin\_ranges\_enabled | Enable admin ranges-based rules. | `bool` | `false` | no |
 | custom\_rules | List of custom rule definitions (refer to variables file for syntax). | <pre>map(object({<br>    description          = string<br>    direction            = string<br>    action               = string # (allow|deny)<br>    ranges               = list(string)<br>    sources              = list(string)<br>    targets              = list(string)<br>    use_service_accounts = bool<br>    rules = list(object({<br>      protocol = string<br>      ports    = list(string)<br>    }))<br>    extra_attributes = map(string)<br>  }))</pre> | `{}` | no |
-| http\_source\_ranges | List of IP CIDR ranges for tag-based HTTP rule, defaults to 0.0.0.0/0. | `list` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| http\_source\_ranges | List of IP CIDR ranges for tag-based HTTP rule, defaults to 0.0.0.0/0. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | http\_target\_tags | List of target tags for tag-based HTTP rule, defaults to http-server. | `list` | <pre>[<br>  "http-server"<br>]</pre> | no |
-| https\_source\_ranges | List of IP CIDR ranges for tag-based HTTPS rule, defaults to 0.0.0.0/0. | `list` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
-| https\_target\_tags | List of target tags for tag-based HTTPS rule, defaults to https-server. | `list` | <pre>[<br>  "https-server"<br>]</pre> | no |
+| https\_source\_ranges | List of IP CIDR ranges for tag-based HTTPS rule, defaults to 0.0.0.0/0. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| https\_target\_tags | List of target tags for tag-based HTTPS rule, defaults to https-server. | `list(string)` | <pre>[<br>  "https-server"<br>]</pre> | no |
 | internal\_allow | Allow rules for internal ranges. | `list` | <pre>[<br>  {<br>    "protocol": "icmp"<br>  }<br>]</pre> | no |
-| internal\_ranges | IP CIDR ranges for intra-VPC rules. | `list` | `[]` | no |
+| internal\_ranges | IP CIDR ranges for intra-VPC rules. | `list(string)` | `[]` | no |
 | internal\_ranges\_enabled | Create rules for intra-VPC ranges. | `bool` | `false` | no |
-| internal\_target\_tags | List of target tags for intra-VPC rules. | `list` | `[]` | no |
-| network | Name of the network this set of firewall rules applies to. | `any` | n/a | yes |
-| project\_id | Project id of the project that holds the network. | `any` | n/a | yes |
-| ssh\_source\_ranges | List of IP CIDR ranges for tag-based SSH rule, defaults to 0.0.0.0/0. | `list` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| internal\_target\_tags | List of target tags for intra-VPC rules. | `list(string)` | `[]` | no |
+| network | Name of the network this set of firewall rules applies to. | `string` | n/a | yes |
+| project\_id | Project id of the project that holds the network. | `string` | n/a | yes |
+| ssh\_source\_ranges | List of IP CIDR ranges for tag-based SSH rule, defaults to 0.0.0.0/0. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | ssh\_target\_tags | List of target tags for tag-based SSH rule, defaults to ssh. | `list` | <pre>[<br>  "ssh"<br>]</pre> | no |
 
 ## Outputs

--- a/modules/fabric-net-firewall/main.tf
+++ b/modules/fabric-net-firewall/main.tf
@@ -133,8 +133,8 @@ resource "google_compute_firewall" "custom" {
   priority                = lookup(each.value.extra_attributes, "priority", 1000)
 
   dynamic "log_config" {
-    for_each = lookup(each.value, "flow_logs", false) ? [{
-      metadata = lookup(each.value, "flow_logs_metadata", "INCLUDE_ALL_METADATA")
+    for_each = lookup(each.value.extra_attributes, "flow_logs", false) ? [{
+      metadata = lookup(each.value.extra_attributes, "flow_logs_metadata", "INCLUDE_ALL_METADATA")
     }] : []
     content {
       metadata = log_config.value.metadata

--- a/modules/fabric-net-firewall/variables.tf
+++ b/modules/fabric-net-firewall/variables.tf
@@ -16,24 +16,29 @@
 
 variable "network" {
   description = "Name of the network this set of firewall rules applies to."
+  type        = string
 }
 
 variable "project_id" {
   description = "Project id of the project that holds the network."
+  type        = string
 }
 
 variable "internal_ranges_enabled" {
   description = "Create rules for intra-VPC ranges."
+  type        = bool
   default     = false
 }
 
 variable "internal_ranges" {
   description = "IP CIDR ranges for intra-VPC rules."
+  type        = list(string)
   default     = []
 }
 
 variable "internal_target_tags" {
   description = "List of target tags for intra-VPC rules."
+  type        = list(string)
   default     = []
 }
 
@@ -48,16 +53,19 @@ variable "internal_allow" {
 
 variable "admin_ranges_enabled" {
   description = "Enable admin ranges-based rules."
+  type        = bool
   default     = false
 }
 
 variable "admin_ranges" {
   description = "IP CIDR ranges that have complete access to all subnets."
+  type        = list(string)
   default     = []
 }
 
 variable "ssh_source_ranges" {
   description = "List of IP CIDR ranges for tag-based SSH rule, defaults to 0.0.0.0/0."
+  type        = list(string)
   default     = ["0.0.0.0/0"]
 }
 
@@ -68,6 +76,7 @@ variable "ssh_target_tags" {
 
 variable "http_source_ranges" {
   description = "List of IP CIDR ranges for tag-based HTTP rule, defaults to 0.0.0.0/0."
+  type        = list(string)
   default     = ["0.0.0.0/0"]
 }
 
@@ -78,11 +87,13 @@ variable "http_target_tags" {
 
 variable "https_source_ranges" {
   description = "List of IP CIDR ranges for tag-based HTTPS rule, defaults to 0.0.0.0/0."
+  type        = list(string)
   default     = ["0.0.0.0/0"]
 }
 
 variable "https_target_tags" {
   description = "List of target tags for tag-based HTTPS rule, defaults to https-server."
+  type        = list(string)
   default     = ["https-server"]
 }
 


### PR DESCRIPTION
With the current version, it is not possible to enable firewall logs. This PR fixes the issue by changing the firewall module to look at the `extra_attributes` inside the `custom_rules` var when dynamically building the `log_config`.
Variable types have also been updated (where it made sense) for fabric-net-firewall module.