### PR TITLE
fix non-internet routes

### DIFF
--- a/modules/routes-beta/main.tf
+++ b/modules/routes-beta/main.tf
@@ -28,7 +28,7 @@ resource "google_compute_route" "route" {
   description            = lookup(var.routes[count.index], "description", null)
   tags                   = compact(split(",", lookup(var.routes[count.index], "tags", "")))
   dest_range             = lookup(var.routes[count.index], "destination_range", null)
-  next_hop_gateway       = lookup(var.routes[count.index], "next_hop_internet", "false") == "true" ? "default-internet-gateway" : ""
+  next_hop_gateway       = lookup(var.routes[count.index], "next_hop_internet", "false") == "true" ? "default-internet-gateway" : null
   next_hop_ip            = lookup(var.routes[count.index], "next_hop_ip", null)
   next_hop_instance      = lookup(var.routes[count.index], "next_hop_instance", null)
   next_hop_instance_zone = lookup(var.routes[count.index], "next_hop_instance_zone", null)


### PR DESCRIPTION
`next_hop_gateway` cannot be passed (even as "") if `next_hop_ilb` is set:
```
Error: ExactlyOne

  on .terraform/modules/base_transitivity.routes/modules/routes-beta/main.tf line 36, in resource "google_compute_route" "route":
  36:   next_hop_ilb           = lookup(var.routes[count.index], "next_hop_ilb", null)

"next_hop_ilb": only one of
`next_hop_gateway,next_hop_ilb,next_hop_instance,next_hop_ip,next_hop_vpn_tunnel`
can be specified, but `next_hop_gateway,next_hop_ilb` were specified.
```