### PR TITLE
fix: Update required Terraform version for firewall-rules submodule

### DIFF
--- a/modules/firewall-rules/versions.tf
+++ b/modules/firewall-rules/versions.tf
@@ -15,8 +15,15 @@
  */
 
 terraform {
-  required_version = ">=0.12.6"
+  required_version = ">= 0.13.0"
   required_providers {
-    google = "<4.0,>= 2.12"
+    google = {
+      source  = "hashicorp/google"
+      version = "<4.0,>= 2.12"
+    }
+  }
+
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-network:firewall-rules/v3.1.0"
   }
 }


### PR DESCRIPTION
Fixes #244