### PR TITLE
Eliminate deprecation warning due to pre-0.12 string interpolation syntax

### DIFF
--- a/modules/firewall-rules/main.tf
+++ b/modules/firewall-rules/main.tf
@@ -15,7 +15,7 @@
  */
 
 resource "google_compute_firewall" "rules" {
-  for_each                = { for r in var.rules : "${r.name}" => r }
+  for_each                = { for r in var.rules : r.name => r }
   name                    = each.value.name
   description             = each.value.description
   direction               = each.value.direction


### PR DESCRIPTION
This PR eliminates the following syntax deprecation warning:

```
Warning: Interpolation-only expressions are deprecated

  on .terraform/modules/network/terraform-google-network-3.1.1/modules/firewall-rules/main.tf line 18, in resource "google_compute_firewall" "rules":
  18:   for_each                = { for r in var.rules : "${r.name}" => r }

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.
```

The version constraints already impose a version of Terraform greater than 0.11
so this has no impact on users other than removing the warning.
