### PR TITLE
Addresses Issue #248 (Add Support for Exporting PUPIs - Network Peering Module)

### DIFF
--- a/modules/firewall-rules/versions.tf
+++ b/modules/firewall-rules/versions.tf
@@ -15,8 +15,15 @@
  */
 
 terraform {
-  required_version = ">=0.12.6"
+  required_version = ">= 0.13.0"
   required_providers {
-    google = "<4.0,>= 2.12"
+    google = {
+      source  = "hashicorp/google"
+      version = "<4.0,>= 2.12"
+    }
+  }
+
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-network:firewall-rules/v3.1.0"
   }
 }

--- a/modules/network-peering/README.md
+++ b/modules/network-peering/README.md
@@ -49,9 +49,9 @@ module "peering-a-c" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | export\_local\_custom\_routes | Export custom routes to peer network from local network. | `bool` | `false` | no |
-| export\_local\_public\_ip\_subnet\_routes | Export custom routes to peer network from local network. | `bool` | `false` | no |
+| export\_local\_subnet\_routes\_with\_public\_ip | Export custom routes to peer network from local network (defaults to true; causes the Local Peering Connection to align with the [provider default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network_peering#export_subnet_routes_with_public_ip), and the Remote Peering Connection to be opposite the provider default). | `bool` | `true` | no |
 | export\_peer\_custom\_routes | Export custom routes to local network from peer network. | `bool` | `false` | no |
-| export\_peer\_public\_ip\_subnet\_routes | Export custom routes to local network from peer network. | `bool` | `false` | no |
+| export\_peer\_subnet\_routes\_with\_public\_ip | Export custom routes to local network from peer network (defaults to false; causes the Local Peering Connection to align with the [provider default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network_peering#import_subnet_routes_with_public_ip), and the Remote Peering Connection to be opposite the provider default). | `bool` | `false` | no |
 | local\_network | Resource link of the network to add a peering to. | `string` | n/a | yes |
 | module\_depends\_on | List of modules or resources this module depends on. | `list(any)` | `[]` | no |
 | peer\_network | Resource link of the peer network. | `string` | n/a | yes |

--- a/modules/network-peering/README.md
+++ b/modules/network-peering/README.md
@@ -49,7 +49,9 @@ module "peering-a-c" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | export\_local\_custom\_routes | Export custom routes to peer network from local network. | `bool` | `false` | no |
+| export\_local\_public\_ip\_subnet\_routes | Export custom routes to peer network from local network. | `bool` | `false` | no |
 | export\_peer\_custom\_routes | Export custom routes to local network from peer network. | `bool` | `false` | no |
+| export\_peer\_public\_ip\_subnet\_routes | Export custom routes to local network from peer network. | `bool` | `false` | no |
 | local\_network | Resource link of the network to add a peering to. | `string` | n/a | yes |
 | module\_depends\_on | List of modules or resources this module depends on. | `list(any)` | `[]` | no |
 | peer\_network | Resource link of the peer network. | `string` | n/a | yes |

--- a/modules/network-peering/main.tf
+++ b/modules/network-peering/main.tf
@@ -38,6 +38,9 @@ resource "google_compute_network_peering" "local_network_peering" {
   export_custom_routes = var.export_local_custom_routes
   import_custom_routes = var.export_peer_custom_routes
 
+  export_subnet_routes_with_public_ip = var.export_local_public_ip_subnet_routes
+  import_subnet_routes_with_public_ip = var.export_peer_public_ip_subnet_routes
+
   depends_on = [null_resource.module_depends_on]
 }
 
@@ -48,6 +51,9 @@ resource "google_compute_network_peering" "peer_network_peering" {
   peer_network         = var.local_network
   export_custom_routes = var.export_peer_custom_routes
   import_custom_routes = var.export_local_custom_routes
+
+  export_subnet_routes_with_public_ip = var.export_peer_public_ip_subnet_routes
+  import_subnet_routes_with_public_ip = var.export_local_public_ip_subnet_routes
 
   depends_on = [null_resource.module_depends_on, google_compute_network_peering.local_network_peering]
 }

--- a/modules/network-peering/main.tf
+++ b/modules/network-peering/main.tf
@@ -30,6 +30,7 @@ resource "random_string" "network_peering_suffix" {
   special = false
   length  = 4
 }
+
 resource "google_compute_network_peering" "local_network_peering" {
   provider             = google-beta
   name                 = local.local_network_peering_name
@@ -38,8 +39,8 @@ resource "google_compute_network_peering" "local_network_peering" {
   export_custom_routes = var.export_local_custom_routes
   import_custom_routes = var.export_peer_custom_routes
 
-  export_subnet_routes_with_public_ip = var.export_local_public_ip_subnet_routes
-  import_subnet_routes_with_public_ip = var.export_peer_public_ip_subnet_routes
+  export_subnet_routes_with_public_ip = var.export_local_subnet_routes_with_public_ip
+  import_subnet_routes_with_public_ip = var.export_peer_subnet_routes_with_public_ip
 
   depends_on = [null_resource.module_depends_on]
 }
@@ -52,8 +53,8 @@ resource "google_compute_network_peering" "peer_network_peering" {
   export_custom_routes = var.export_peer_custom_routes
   import_custom_routes = var.export_local_custom_routes
 
-  export_subnet_routes_with_public_ip = var.export_peer_public_ip_subnet_routes
-  import_subnet_routes_with_public_ip = var.export_local_public_ip_subnet_routes
+  export_subnet_routes_with_public_ip = var.export_peer_subnet_routes_with_public_ip
+  import_subnet_routes_with_public_ip = var.export_local_subnet_routes_with_public_ip
 
   depends_on = [null_resource.module_depends_on, google_compute_network_peering.local_network_peering]
 }

--- a/modules/network-peering/variables.tf
+++ b/modules/network-peering/variables.tf
@@ -42,6 +42,18 @@ variable "export_local_custom_routes" {
   default     = false
 }
 
+variable "export_peer_public_ip_subnet_routes" {
+  description = "Export custom routes to local network from peer network."
+  type        = bool
+  default     = false
+}
+
+variable "export_local_public_ip_subnet_routes" {
+  description = "Export custom routes to peer network from local network."
+  type        = bool
+  default     = false
+}
+
 variable "module_depends_on" {
   description = "List of modules or resources this module depends on."
   type        = list(any)

--- a/modules/network-peering/variables.tf
+++ b/modules/network-peering/variables.tf
@@ -42,16 +42,16 @@ variable "export_local_custom_routes" {
   default     = false
 }
 
-variable "export_peer_public_ip_subnet_routes" {
-  description = "Export custom routes to local network from peer network."
+variable "export_peer_subnet_routes_with_public_ip" {
+  description = "Export custom routes to local network from peer network (defaults to false; causes the Local Peering Connection to align with the [provider default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network_peering#import_subnet_routes_with_public_ip), and the Remote Peering Connection to be opposite the provider default)."
   type        = bool
   default     = false
 }
 
-variable "export_local_public_ip_subnet_routes" {
-  description = "Export custom routes to peer network from local network."
+variable "export_local_subnet_routes_with_public_ip" {
+  description = "Export custom routes to peer network from local network (defaults to true; causes the Local Peering Connection to align with the [provider default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network_peering#export_subnet_routes_with_public_ip), and the Remote Peering Connection to be opposite the provider default)."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "module_depends_on" {


### PR DESCRIPTION
This introduces support for the export_subnet_routes_with_public_ip and import_subnet_routes_with_public_ip variables in the google_compute_network_peering resources. This is necessary when peering VPCs that are using Privately Used Public IPs (PUPIs) as the private subnet IPs.

Note - the defaults proposed in this PR are false for both variables, but the provider's default for [export_subnet_routes_with_public_ip](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network_peering#export_subnet_routes_with_public_ip) is true (the import variable is also set to false, by default, here); because these come in pairs (defining each end of the peering), and because the current Network Peering submodule doesn't override these defaults, it will cause each peering will attempt to export these subnets but neither peering will attempt to import them; not a problem, really, but the proposed solution also addresses this incongruence, by default.

Fixes #248