### PR TITLE
added naming convention support for peering

### DIFF
--- a/modules/network-peering/README.md
+++ b/modules/network-peering/README.md
@@ -53,9 +53,10 @@ module "peering-a-c" {
 | export\_peer\_custom\_routes | Export custom routes to local network from peer network. | `bool` | `false` | no |
 | export\_peer\_subnet\_routes\_with\_public\_ip | Export custom routes to local network from peer network (defaults to false; causes the Local Peering Connection to align with the [provider default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network_peering#import_subnet_routes_with_public_ip), and the Remote Peering Connection to be opposite the provider default). | `bool` | `false` | no |
 | local\_network | Resource link of the network to add a peering to. | `string` | n/a | yes |
+| local\_peering\_name | Name for the local peering | `string` | `""` | no |
 | module\_depends\_on | List of modules or resources this module depends on. | `list(any)` | `[]` | no |
 | peer\_network | Resource link of the peer network. | `string` | n/a | yes |
-| prefix | Name prefix for the network peerings | `string` | `"network-peering"` | no |
+| peer\_peering\_name | Name for the peer peering | `string` | `""` | no |
 
 ## Outputs
 

--- a/modules/network-peering/main.tf
+++ b/modules/network-peering/main.tf
@@ -16,7 +16,7 @@
 
 locals {
   default_prefix = "network-peering"
-  
+
   local_network_name = element(reverse(split("/", var.local_network)), 0)
   peer_network_name  = element(reverse(split("/", var.peer_network)), 0)
 

--- a/modules/network-peering/main.tf
+++ b/modules/network-peering/main.tf
@@ -15,13 +15,16 @@
  */
 
 locals {
+  default_prefix = "network-peering"
+  
   local_network_name = element(reverse(split("/", var.local_network)), 0)
   peer_network_name  = element(reverse(split("/", var.peer_network)), 0)
 
-  local_network_peering      = "${var.prefix}-${local.local_network_name}-${local.peer_network_name}"
-  local_network_peering_name = length(local.local_network_peering) < 63 ? local.local_network_peering : "${substr(local.local_network_peering, 0, min(58, length(local.local_network_peering)))}-${random_string.network_peering_suffix.result}"
-  peer_network_peering       = "${var.prefix}-${local.peer_network_name}-${local.local_network_name}"
-  peer_network_peering_name  = length(local.peer_network_peering) < 63 ? local.peer_network_peering : "${substr(local.peer_network_peering, 0, min(58, length(local.peer_network_peering)))}-${random_string.network_peering_suffix.result}"
+  local_network_peering = "${local.default_prefix}-${local.local_network_name}-${local.peer_network_name}"
+  local_peering_name    = var.local_peering_name != "" && length(var.local_peering_name) < 63 ? var.local_peering_name : "${substr(local.local_network_peering, 0, min(58, length(local.local_network_peering)))}-${random_string.network_peering_suffix.result}"
+
+  peer_network_peering = "${local.default_prefix}-${local.peer_network_name}-${local.local_network_name}"
+  peer_peering_name    = var.peer_peering_name != "" && length(var.peer_peering_name) < 63 ? var.peer_peering_name : "${substr(local.peer_network_peering, 0, min(58, length(local.peer_network_peering)))}-${random_string.network_peering_suffix.result}"
 }
 
 resource "random_string" "network_peering_suffix" {
@@ -33,7 +36,7 @@ resource "random_string" "network_peering_suffix" {
 
 resource "google_compute_network_peering" "local_network_peering" {
   provider             = google-beta
-  name                 = local.local_network_peering_name
+  name                 = local.local_peering_name
   network              = var.local_network
   peer_network         = var.peer_network
   export_custom_routes = var.export_local_custom_routes
@@ -47,7 +50,7 @@ resource "google_compute_network_peering" "local_network_peering" {
 
 resource "google_compute_network_peering" "peer_network_peering" {
   provider             = google-beta
-  name                 = local.peer_network_peering_name
+  name                 = local.peer_peering_name
   network              = var.peer_network
   peer_network         = var.local_network
   export_custom_routes = var.export_peer_custom_routes

--- a/modules/network-peering/variables.tf
+++ b/modules/network-peering/variables.tf
@@ -14,10 +14,16 @@
  * limitations under the License.
  */
 
-variable "prefix" {
-  description = "Name prefix for the network peerings"
+variable "local_peering_name" {
+  description = "Name for the local peering"
   type        = string
-  default     = "network-peering"
+  default     = ""
+}
+
+variable "peer_peering_name" {
+  description = "Name for the peer peering"
+  type        = string
+  default     = ""
 }
 
 variable "local_network" {

--- a/test/setup/README.md
+++ b/test/setup/README.md
@@ -32,4 +32,4 @@ integration tests from your machine.
 
 Alternatively, to run the integration tests directly from the Docker
 container used by the module's CI pipeline, perform the above steps and then
-run the `make test_integration_docker` target
+run the `make docker_test_integration` target


### PR DESCRIPTION
This change was needed by a customer who needs to follow naming conventions.
Basically I added names for local and peer network peering and if this is set the prefix will be removed. If you want to add a prefix you have to set the name and add the prefix in front. 