### PR TITLE
Added snippet that creates a VM with the reserved IP address

### DIFF
--- a/examples/basic_shared_vpc/README.md
+++ b/examples/basic_shared_vpc/README.md
@@ -5,10 +5,11 @@ This example:
 * Enables shared VPC on a host project
 * Attaches a service project
 * Reserves an internal IP address in a subnet of a Shared VPC network
+* Creates a VM instance
 
-Note that the IP address configuration object is created in the service
-project, while its value comes from the range of available addresses in
-the chosen shared subnet.
+The IP address configuration object is created in the service
+project. Its value can come from the range of available addresses in
+the chosen shared subnet, or you can specify an address.
 
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/basic_shared_vpc/main.tf
+++ b/examples/basic_shared_vpc/main.tf
@@ -55,8 +55,26 @@ resource "google_compute_address" "internal" {
 }
 # [END compute_shared_internal_ip_create]
 
-# [START compute_shared_instance_create]
-resource "google_compute_instance" "default" {
+# [START compute_shared_instance_with_reserved_ip_create]
+resource "google_compute_instance" "reserved_ip" {
+  project      = var.service_project
+  zone         = "us-central1-a"
+  name         = "my-vm"
+  machine_type = "e2-medium"
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+  network_interface {
+    subnetwork = data.google_compute_subnetwork.subnet.self_link
+    network_ip = "int-ip"
+  }
+}
+# [END compute_shared_instance_with_reserved_ip_create]
+
+# [START compute_shared_instance_with_ephemeral_ip_create]
+resource "google_compute_instance" "ephemeral_ip" {
   project      = var.service_project
   zone         = "us-central1-a"
   name         = "my-vm"
@@ -70,4 +88,4 @@ resource "google_compute_instance" "default" {
     subnetwork = data.google_compute_subnetwork.subnet.self_link
   }
 }
-# [END compute_shared_instance_create]
+# [END compute_shared_instance_with_ephemeral_ip_create]


### PR DESCRIPTION
Added snippet that creates a VM with the reserved IP address

This allows us to have a Terraform that more closely matches the other tabs in the https://cloud.devsite.corp.google.com/vpc/docs/provisioning-shared-vpc#creating_an_instance_in_a_shared_subnet section