### PR TITLE
chore: adding command to set Network Service Tier for a project

### DIFF
--- a/examples/network_service_tiers/README.md
+++ b/examples/network_service_tiers/README.md
@@ -1,0 +1,16 @@
+#  Network Service Tier
+
+This example configures the Network Service Tier for a project.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| project\_id | The project ID to set the Network Service Tier in | `any` | n/a | yes |
+
+## Outputs
+
+No output.
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/network_service_tiers/README.md
+++ b/examples/network_service_tiers/README.md
@@ -11,7 +11,9 @@ This example configures the Network Service Tier for a project.
 
 ## Outputs
 
-No output.
+| Name | Description |
+|------|-------------|
+| project\_id | Google Cloud project ID |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/examples/network_service_tiers/README.md
+++ b/examples/network_service_tiers/README.md
@@ -14,3 +14,4 @@ This example configures the Network Service Tier for a project.
 No output.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+

--- a/examples/network_service_tiers/main.tf
+++ b/examples/network_service_tiers/main.tf
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 provider "null" {
   version = "~> 2.1"
 }
@@ -29,3 +28,4 @@ resource "google_compute_project_default_network_tier" "project-tier" {
   network_tier = "STANDARD"
 }
 # [END networkservicetiers_project_tier_set]
+

--- a/examples/network_service_tiers/main.tf
+++ b/examples/network_service_tiers/main.tf
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+provider "null" {
+  version = "~> 2.1"
+}
+
+provider "google" {
+  version = "~> 3.45.0"
+}
+
+# [START networkservicetiers_project_tier_set]
+resource "google_compute_project_default_network_tier" "project-tier" {
+  project     = var.project_id # Replace this with your project ID in quotes
+  network_tier = "STANDARD"
+}
+# [END networkservicetiers_project_tier_set]

--- a/examples/network_service_tiers/main.tf
+++ b/examples/network_service_tiers/main.tf
@@ -24,7 +24,7 @@ provider "google" {
 
 # [START networkservicetiers_project_tier_set]
 resource "google_compute_project_default_network_tier" "project-tier" {
-  project     = var.project_id # Replace this with your project ID in quotes
+  project      = var.project_id # Replace this with your project ID in quotes
   network_tier = "STANDARD"
 }
 # [END networkservicetiers_project_tier_set]

--- a/examples/network_service_tiers/outputs.tf
+++ b/examples/network_service_tiers/outputs.tf
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "project_id" {
+  value       = google_compute_project_default_network_tier.project-tier.project
+  description = "Google Cloud project ID"
+}
+

--- a/examples/network_service_tiers/variables.tf
+++ b/examples/network_service_tiers/variables.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The project ID to set the Network Service Tier in"
+}

--- a/examples/network_service_tiers/variables.tf
+++ b/examples/network_service_tiers/variables.tf
@@ -17,3 +17,4 @@
 variable "project_id" {
   description = "The project ID to set the Network Service Tier in"
 }
+

--- a/examples/network_service_tiers/versions.tf
+++ b/examples/network_service_tiers/versions.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">=0.12.6"
+}

--- a/examples/network_service_tiers/versions.tf
+++ b/examples/network_service_tiers/versions.tf
@@ -17,3 +17,4 @@
 terraform {
   required_version = ">=0.12.6"
 }
+


### PR DESCRIPTION
Purpose is to add Terraform tab to
https://cloud.google.com/network-tiers/docs/using-network-service-tiers#setting_the_tier_for_all_resources_in_a_project