### PR TITLE
Simplified secondary range module example

### DIFF
--- a/examples/secondary_ranges/README.md
+++ b/examples/secondary_ranges/README.md
@@ -3,7 +3,7 @@
 This example creates a single simple VPC network inside of a project.
 
 This VPC network has three subnets. The first subnet has two secondary
-ranges and the third has a single secondary range.
+ranges, and the third has a single secondary range.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs

--- a/examples/secondary_ranges/README.md
+++ b/examples/secondary_ranges/README.md
@@ -1,9 +1,9 @@
 # Secondary Ranges
 
-This example configures a single simple VPC inside of a project.
+This example creates a single simple VPC network inside of a project.
 
-This VPC has three subnets, with the first subnet being given two secondary
-ranges and the third being given a single secondary range.
+This VPC network has three subnets. The first subnet has two secondary
+ranges and the third has a single secondary range.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
@@ -20,8 +20,6 @@ ranges and the third being given a single secondary range.
 | network\_name | The name of the VPC being created |
 | network\_self\_link | The URI of the VPC being created |
 | project\_id | VPC project id |
-| route\_names | The routes associated with this VPC |
-| subnets\_flow\_logs | Whether the subnets will have VPC flow logs enabled |
 | subnets\_ips | The IP and cidrs of the subnets being created |
 | subnets\_names | The names of the subnets being created |
 | subnets\_private\_access | Whether the subnets will have access to Google API's without a public IP |

--- a/examples/secondary_ranges/main.tf
+++ b/examples/secondary_ranges/main.tf
@@ -26,13 +26,13 @@ locals {
   subnet_01 = "${var.network_name}-subnet-01"
   subnet_02 = "${var.network_name}-subnet-02"
   subnet_03 = "${var.network_name}-subnet-03"
-  subnet_04 = "${var.network_name}-subnet-04"
 }
 
 module "vpc-secondary-ranges" {
-  source       = "../../"
-  project_id   = var.project_id
-  network_name = var.network_name
+  source       = "terraform-google-modules/network/google"
+  version      = "~> 3.2.0"
+  project_id   = var.project_id   # Replace this with your project ID in quotes
+  network_name = var.network_name # Replace this with the VPC network to create in quotes
 
   subnets = [
     {
@@ -41,24 +41,13 @@ module "vpc-secondary-ranges" {
       subnet_region = "us-west1"
     },
     {
-      subnet_name           = "${local.subnet_02}"
-      subnet_ip             = "10.10.20.0/24"
-      subnet_region         = "us-west1"
-      subnet_private_access = "true"
-      subnet_flow_logs      = "true"
+      subnet_name   = "${local.subnet_02}"
+      subnet_ip     = "10.10.20.0/24"
+      subnet_region = "us-west1"
     },
     {
-      subnet_name               = "${local.subnet_03}"
-      subnet_ip                 = "10.10.30.0/24"
-      subnet_region             = "us-west1"
-      subnet_flow_logs          = "true"
-      subnet_flow_logs_interval = "INTERVAL_15_MIN"
-      subnet_flow_logs_sampling = 0.9
-      subnet_flow_logs_metadata = "INCLUDE_ALL_METADATA"
-    },
-    {
-      subnet_name   = "${local.subnet_04}"
-      subnet_ip     = "10.10.40.0/24"
+      subnet_name   = "${local.subnet_03}"
+      subnet_ip     = "10.10.30.0/24"
       subnet_region = "us-west1"
     },
   ]
@@ -84,28 +73,4 @@ module "vpc-secondary-ranges" {
       },
     ]
   }
-
-  firewall_rules = [
-    {
-      name      = "allow-ssh-ingress"
-      direction = "INGRESS"
-      ranges    = ["0.0.0.0/0"]
-      allow = [{
-        protocol = "tcp"
-        ports    = ["22"]
-      }]
-      log_config = {
-        metadata = "INCLUDE_ALL_METADATA"
-      }
-    },
-    {
-      name      = "deny-udp-egress"
-      direction = "INGRESS"
-      ranges    = ["0.0.0.0/0"]
-      deny = [{
-        protocol = "udp"
-        ports    = null
-      }]
-    },
-  ]
 }

--- a/examples/secondary_ranges/outputs.tf
+++ b/examples/secondary_ranges/outputs.tf
@@ -49,17 +49,7 @@ output "subnets_private_access" {
   description = "Whether the subnets will have access to Google API's without a public IP"
 }
 
-output "subnets_flow_logs" {
-  value       = module.vpc-secondary-ranges.subnets_flow_logs
-  description = "Whether the subnets will have VPC flow logs enabled"
-}
-
 output "subnets_secondary_ranges" {
   value       = flatten(module.vpc-secondary-ranges.subnets_secondary_ranges)
   description = "The secondary ranges associated with these subnets"
-}
-
-output "route_names" {
-  value       = module.vpc-secondary-ranges.route_names
-  description = "The routes associated with this VPC"
 }


### PR DESCRIPTION
When I started these changes, I was intending to use the example in https://cloud.devsite.corp.google.com/vpc/docs/configure-alias-ip-ranges#creating_a_subnet_with_one_or_more_secondary_cidr_ranges.

However, given the clarified guidance about using resources (instead of modules) for simple examples, I'm planning to create a new example based on https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork.

Also note that I wasn't able to remove the local variables. I think this is a constraint based on the underlying module definition.

Even though I'm not planning to use this c.g.c., it might still be worth merging this PR.