### PR TITLE
Added new example for a subnet with a secondary range

### DIFF
--- a/examples/basic_secondary_ranges/README.md
+++ b/examples/basic_secondary_ranges/README.md
@@ -1,0 +1,23 @@
+# Subnet with secondary range
+
+This example configures a VPC network and a subnet with a secondary range.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| project\_id | The project ID to host the network in | `any` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| primary\_cidr | Primary CIDR range |
+| project\_id | Google Cloud project ID |
+| region | Google Cloud region |
+| secondary\_cidr | Secondary CIDR range |
+| secondary\_cidr\_name | Name of the secondary CIDR range |
+| subnetwork\_name | The name of the subnetwork |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/basic_secondary_ranges/main.tf
+++ b/examples/basic_secondary_ranges/main.tf
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+terraform {
+  required_providers {
+    google = {
+      version = ">= 3.45.0"
+    }
+    null = {
+      version = ">= 2.1.0"
+    }
+  }
+}
+
+# [START vpc_secondary_range_create]
+resource "google_compute_subnetwork" "network-with-private-secondary-ip-ranges" {
+  project       = var.project_id # Replace this with your project ID in quotes
+  name          = "test-subnetwork"
+  ip_cidr_range = "10.2.0.0/16"
+  region        = "us-central1"
+  network       = "test-vpc-network"
+  secondary_ip_range {
+    range_name    = "tf-test-secondary-range-update1"
+    ip_cidr_range = "192.168.10.0/24"
+  }
+}
+# [END vpc_secondary_range_create]

--- a/examples/basic_secondary_ranges/outputs.tf
+++ b/examples/basic_secondary_ranges/outputs.tf
@@ -15,7 +15,7 @@
  */
 
 output "project_id" {
-  value       = google_compute_network.custom-test.project
+  value       = google_compute_subnetwork.network-with-private-secondary-ip-ranges.project
   description = "Google Cloud project ID"
 }
 

--- a/examples/basic_secondary_ranges/outputs.tf
+++ b/examples/basic_secondary_ranges/outputs.tf
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "project_id" {
+  value       = google_compute_network.custom-test.project
+  description = "Google Cloud project ID"
+}
+
+output "region" {
+  value       = google_compute_subnetwork.network-with-private-secondary-ip-ranges.region
+  description = "Google Cloud region"
+}
+
+output "subnetwork_name" {
+  value       = google_compute_subnetwork.network-with-private-secondary-ip-ranges.name
+  description = "The name of the subnetwork"
+}
+
+output "primary_cidr" {
+  value       = google_compute_subnetwork.network-with-private-secondary-ip-ranges.ip_cidr_range
+  description = "Primary CIDR range"
+}
+
+output "secondary_cidr_name" {
+  value       = google_compute_subnetwork.network-with-private-secondary-ip-ranges.secondary_ip_range[0].range_name
+  description = "Name of the secondary CIDR range"
+}
+
+output "secondary_cidr" {
+  value       = google_compute_subnetwork.network-with-private-secondary-ip-ranges.secondary_ip_range[0].ip_cidr_range
+  description = "Secondary CIDR range"
+}

--- a/examples/basic_secondary_ranges/variables.tf
+++ b/examples/basic_secondary_ranges/variables.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The project ID to host the network in"
+}

--- a/examples/basic_secondary_ranges/versions.tf
+++ b/examples/basic_secondary_ranges/versions.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">=0.12.6"
+}


### PR DESCRIPTION
Intending to use this here:
https://cloud.devsite.corp.google.com/vpc/docs/configure-alias-ip-ranges#creating_a_subnet_with_one_or_more_secondary_cidr_ranges