### PR TITLE
Adds `subnet_ids` as an output

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Then perform the following commands on the root folder:
 | route\_names | The route names associated with this VPC |
 | subnets | A map with keys of form subnet\_region/subnet\_name and values being the outputs of the google\_compute\_subnetwork resources used to create corresponding subnets. |
 | subnets\_flow\_logs | Whether the subnets will have VPC flow logs enabled |
+| subnets\_ids | The IDs of the subnets being created |
 | subnets\_ips | The IPs and CIDRs of the subnets being created |
 | subnets\_names | The names of the subnets being created |
 | subnets\_private\_access | Whether the subnets will have access to Google API's without a public IP |

--- a/outputs.tf
+++ b/outputs.tf
@@ -44,6 +44,11 @@ output "subnets_names" {
   description = "The names of the subnets being created"
 }
 
+output "subnets_ids" {
+  value       = [for network in module.subnets.subnets : network.id]
+  description = "The IDs of the subnets being created"
+}
+
 output "subnets_ips" {
   value       = [for network in module.subnets.subnets : network.ip_cidr_range]
   description = "The IPs and CIDRs of the subnets being created"


### PR DESCRIPTION
Just adds every `subnet_id` as an output. Useful for use with other modules that requires a list of the subnet ids.