### PR TITLE
Changed START to END for closing region tag

### DIFF
--- a/examples/private_service_connect_google_apis/main.tf
+++ b/examples/private_service_connect_google_apis/main.tf
@@ -56,4 +56,4 @@ resource "google_compute_global_forwarding_rule" "default" {
   ip_address            = google_compute_global_address.default.id
   load_balancing_scheme = ""
 }
-# [START compute_forwarding_rule_private_access]
+# [END compute_forwarding_rule_private_access]


### PR DESCRIPTION
Used on this page:

https://cloud.google.com/vpc/docs/configure-private-service-connect-apis