### PR TITLE
fix: Refactored IAM binding for network users

### DIFF
--- a/modules/fabric-net-svpc-access/main.tf
+++ b/modules/fabric-net-svpc-access/main.tf
@@ -23,15 +23,13 @@ resource "google_compute_shared_vpc_service_project" "projects" {
 }
 
 resource "google_compute_subnetwork_iam_binding" "network_users" {
-  count      = length(var.host_subnets)
-  project    = var.host_project_id
-  region     = element(var.host_subnet_regions, count.index)
-  subnetwork = element(var.host_subnets, count.index)
-  role       = "roles/compute.networkUser"
+  for_each = { for i, k in var.host_subnets : k => i }
 
-  members = compact(split(",", lookup(var.host_subnet_users,
-    element(var.host_subnets, count.index))
-  ))
+  project    = var.host_project_id
+  region     = element(var.host_subnet_regions, each.value)
+  subnetwork = each.key
+  role       = "roles/compute.networkUser"
+  members    = compact(split(",", lookup(var.host_subnet_users, each.key)))
 }
 
 resource "google_project_iam_binding" "service_agents" {


### PR DESCRIPTION
Replaced `count` with `for_each` on `google_compute_subnetwork_iam_binding` to prevent destroy/recreate when the list changes. 

My institution uses the same codebase from Google CFT, and I did the same refactoring on our end to minimize unnecessary drifts when list changes... so, just contributing this fix back to your codebase if deemed worthy. Thank you.