### PR TITLE
Adding Network ID as a top level module output

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Then perform the following commands on the root folder:
 | Name | Description |
 |------|-------------|
 | network | The created network |
+| network\_id | The ID of the VPC being created |
 | network\_name | The name of the VPC being created |
 | network\_self\_link | The URI of the VPC being created |
 | project\_id | VPC project id |

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -42,6 +42,7 @@ module "vpc" {
 | Name | Description |
 |------|-------------|
 | network | The VPC resource being created |
+| network\_id | The ID of the VPC being created |
 | network\_name | The name of the VPC being created |
 | network\_self\_link | The URI of the VPC being created |
 | project\_id | VPC project id |

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -24,6 +24,11 @@ output "network_name" {
   description = "The name of the VPC being created"
 }
 
+output "network_id" {
+  value       = google_compute_network.network.id
+  description = "The ID of the VPC being created"
+}
+
 output "network_self_link" {
   value       = google_compute_network.network.self_link
   description = "The URI of the VPC being created"

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,6 +29,11 @@ output "network_name" {
   description = "The name of the VPC being created"
 }
 
+output "network_id" {
+  value       = module.vpc.network_id
+  description = "The ID of the VPC being created"
+}
+
 output "network_self_link" {
   value       = module.vpc.network_self_link
   description = "The URI of the VPC being created"


### PR DESCRIPTION
Fixes issue #307

As per the above issue, this PR adds a `network_id` output to the root module and the `vpc` module.

This is my first contribution to this project, do let me know if I have missed something; will be happy to modify the PR accordingly!