### PR TITLE
Add max_throughput to vpc-serverless-connector-beta

### DIFF
--- a/modules/vpc-serverless-connector-beta/README.md
+++ b/modules/vpc-serverless-connector-beta/README.md
@@ -23,6 +23,7 @@ module "serverless-connector" {
     machine_type    = "e2-standard-4"
     min_instances   = 2
     max_instances   = 3
+    max_throughput  = 300
   }]
 }
 ```

--- a/modules/vpc-serverless-connector-beta/main.tf
+++ b/modules/vpc-serverless-connector-beta/main.tf
@@ -31,7 +31,8 @@ resource "google_vpc_access_connector" "connector_beta" {
       project_id = lookup(each.value, "host_project_id", null)
     }
   }
-  machine_type  = lookup(each.value, "machine_type", null)
-  min_instances = lookup(each.value, "min_instances", null)
-  max_instances = lookup(each.value, "max_instances", null)
+  machine_type   = lookup(each.value, "machine_type", null)
+  min_instances  = lookup(each.value, "min_instances", null)
+  max_instances  = lookup(each.value, "max_instances", null)
+  max_throughput = lookup(each.value, "max_throughput", null)
 }


### PR DESCRIPTION
Expose the max_throughput argument of the google_vpc_access_connector.