### PR TITLE
require google-beta also in the root module, not just in vpc module

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -21,6 +21,10 @@ terraform {
       source  = "hashicorp/google"
       version = "<4.0,>= 2.12"
     }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 3.45"
+    }
   }
 
   provider_meta "google" {


### PR DESCRIPTION
As discussed in #326, we require `google-beta` in the [vpc module](https://github.com/terraform-google-modules/terraform-google-network/blob/master/modules/vpc/main.tf#L33), but don't specify it in the root module, leading to the warning:

```
Warning: Provider google-beta is undefined

  on main.tf line 31, in module "vpc":
  31:     google-beta = google-beta.dev

Module module.vpc does not declare a provider named google-beta.
If you wish to specify a provider configuration for the module, add an
entry for google-beta in the required_providers block within the module.
```