### PR TITLE
Promote role and purpose of subnet to GA

### DIFF
--- a/examples/multi_vpc/main.tf
+++ b/examples/multi_vpc/main.tf
@@ -79,7 +79,7 @@ module "test-vpc-module-01" {
   ]
 
   secondary_ranges = {
-    "${local.network_01_subnet_01}" = [
+    (local.network_01_subnet_01) = [
       {
         range_name    = "${local.network_01_subnet_01}-01"
         ip_cidr_range = "192.168.64.0/24"
@@ -90,7 +90,7 @@ module "test-vpc-module-01" {
       },
     ]
 
-    "${local.network_01_subnet_02}" = [
+    (local.network_01_subnet_02) = [
       {
         range_name    = "${local.network_02_subnet_01}-01"
         ip_cidr_range = "192.168.74.0/24"
@@ -108,14 +108,14 @@ module "test-vpc-module-02" {
 
   subnets = [
     {
-      subnet_name           = "${local.network_02_subnet_01}"
+      subnet_name           = local.network_02_subnet_01
       subnet_ip             = "10.10.40.0/24"
       subnet_region         = "us-west1"
       subnet_private_access = "false"
       subnet_flow_logs      = "true"
     },
     {
-      subnet_name           = "${local.network_02_subnet_02}"
+      subnet_name           = local.network_02_subnet_02
       subnet_ip             = "10.10.50.0/24"
       subnet_region         = "us-west1"
       subnet_private_access = "false"
@@ -124,7 +124,7 @@ module "test-vpc-module-02" {
   ]
 
   secondary_ranges = {
-    "${local.network_02_subnet_01}" = [
+    (local.network_02_subnet_01) = [
       {
         range_name    = "${local.network_02_subnet_02}-01"
         ip_cidr_range = "192.168.75.0/24"

--- a/examples/secondary_ranges/main.tf
+++ b/examples/secondary_ranges/main.tf
@@ -28,19 +28,19 @@ module "vpc-secondary-ranges" {
 
   subnets = [
     {
-      subnet_name   = "${local.subnet_01}"
+      subnet_name   = local.subnet_01
       subnet_ip     = "10.10.10.0/24"
       subnet_region = "us-west1"
     },
     {
-      subnet_name           = "${local.subnet_02}"
+      subnet_name           = local.subnet_02
       subnet_ip             = "10.10.20.0/24"
       subnet_region         = "us-west1"
       subnet_private_access = "true"
       subnet_flow_logs      = "true"
     },
     {
-      subnet_name               = "${local.subnet_03}"
+      subnet_name               = local.subnet_03
       subnet_ip                 = "10.10.30.0/24"
       subnet_region             = "us-west1"
       subnet_flow_logs          = "true"
@@ -49,14 +49,14 @@ module "vpc-secondary-ranges" {
       subnet_flow_logs_metadata = "INCLUDE_ALL_METADATA"
     },
     {
-      subnet_name   = "${local.subnet_04}"
+      subnet_name   = local.subnet_04
       subnet_ip     = "10.10.40.0/24"
       subnet_region = "us-west1"
     },
   ]
 
   secondary_ranges = {
-    "${local.subnet_01}" = [
+    (local.subnet_01) = [
       {
         range_name    = "${local.subnet_01}-01"
         ip_cidr_range = "192.168.64.0/24"
@@ -67,9 +67,9 @@ module "vpc-secondary-ranges" {
       },
     ]
 
-    "${local.subnet_02}" = []
+    (local.subnet_02) = []
 
-    "${local.subnet_03}" = [
+    (local.subnet_03) = [
       {
         range_name    = "${local.subnet_03}-01"
         ip_cidr_range = "192.168.66.0/24"

--- a/examples/simple_project/main.tf
+++ b/examples/simple_project/main.tf
@@ -23,7 +23,7 @@
 # [START vpc_custom_create]
 module "test-vpc-module" {
   source       = "terraform-google-modules/network/google"
-  version      = "~> 3.2.0"
+  version      = "~> 4.0.1"
   project_id   = var.project_id # Replace this with your project ID in quotes
   network_name = "my-custom-mode-network"
   mtu          = 1460

--- a/examples/simple_project/versions.tf
+++ b/examples/simple_project/versions.tf
@@ -19,7 +19,7 @@ terraform {
 
   required_providers {
     google = {
-      version = "~> 3.45.0"
+      version = "~> 4.0"
     }
     null = {
       version = "~> 2.1"

--- a/modules/subnets/main.tf
+++ b/modules/subnets/main.tf
@@ -56,4 +56,7 @@ resource "google_compute_subnetwork" "subnetwork" {
     )) :
     var.secondary_ranges[each.value.subnet_name][i]
   ]
+
+  purpose = lookup(each.value, "purpose", null)
+  role    = lookup(each.value, "role", null)
 }


### PR DESCRIPTION
Closes: https://github.com/terraform-google-modules/terraform-google-network/pull/340

in v4 https://github.com/hashicorp/terraform-provider-google/pull/10429, beta clients got stripped from ga provider and the following diffs started appearing when the ga provider was using beta endpoints.﻿

```
Terraform will perform the following actions:

  # module.vpc.module.subnets.google_compute_subnetwork.subnetwork["europe-west1/proxy-only-subnet"] will be updated in-place
  ~ resource "google_compute_subnetwork" "subnetwork" {
        id                         = "projects/REDACTED/regions/europe-west1/subnetworks/proxy-only-subnet"
        name                       = "proxy-only-subnet"
      - role                       = "ACTIVE" -> null
        # (12 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }
```

@bharathkkb 