### PR TITLE
Remove extra forward slash from example source

### DIFF
--- a/examples/basic_vpc_peering/main.tf
+++ b/examples/basic_vpc_peering/main.tf
@@ -22,7 +22,7 @@
 
 # [START vpc_peering_create]
 module "peering1" {
-  source        = "terraform-google-modules/network/google//modules/network-peering"
+  source        = "terraform-google-modules/network/google/modules/network-peering"
   version       = "~> 3.2.1"
   local_network = var.local_network # Replace with self link to VPC network "foobar" in quotes
   peer_network  = var.peer_network  # Replace with self link to VPC network "other" in quotes


### PR DESCRIPTION
It's a pretty minor change. I just removed an extra forward slash in the source path example. The double forward slashes do show up in [GCP's docs](https://cloud.google.com/vpc/docs/using-vpc-peering#terraform).