### PR TITLE
feat: add filter_expr control in subnet log_config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,14 +24,6 @@ Session.vim
 # Local .terraform directories
 **/.terraform/*
 .terraform.lock.hcl
-.terraform/
-*.tfstate
-*.tfstate.backup
-*.tfvars
-*.code-workspace
-.terraform.lock.hcl
-.terragrunt-cache
-terragrunt.hcl
 
 # .tfstate files
 *.tfstate

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,14 @@ Session.vim
 # Local .terraform directories
 **/.terraform/*
 .terraform.lock.hcl
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfvars
+*.code-workspace
+.terraform.lock.hcl
+.terragrunt-cache
+terragrunt.hcl
 
 # .tfstate files
 *.tfstate

--- a/examples/simple_project/main.tf
+++ b/examples/simple_project/main.tf
@@ -49,6 +49,8 @@ module "test-vpc-module" {
       subnet_flow_logs_interval = "INTERVAL_10_MIN"
       subnet_flow_logs_sampling = 0.7
       subnet_flow_logs_metadata = "INCLUDE_ALL_METADATA"
+      // New
+      subnet_flow_logs_filter = "true"
     }
   ]
 }

--- a/examples/simple_project/main.tf
+++ b/examples/simple_project/main.tf
@@ -49,8 +49,7 @@ module "test-vpc-module" {
       subnet_flow_logs_interval = "INTERVAL_10_MIN"
       subnet_flow_logs_sampling = 0.7
       subnet_flow_logs_metadata = "INCLUDE_ALL_METADATA"
-      // New
-      subnet_flow_logs_filter = "true"
+      subnet_flow_logs_filter   = "false"
     }
   ]
 }

--- a/modules/subnets/README.md
+++ b/modules/subnets/README.md
@@ -33,13 +33,14 @@ module "vpc" {
             description           = "This subnet has a description"
         },
         {
-            subnet_name               = "subnet-03"
-            subnet_ip                 = "10.10.30.0/24"
-            subnet_region             = "us-west1"
-            subnet_flow_logs          = "true"
-            subnet_flow_logs_interval = "INTERVAL_10_MIN"
-            subnet_flow_logs_sampling = 0.7
-            subnet_flow_logs_metadata = "INCLUDE_ALL_METADATA"
+            subnet_name                  = "subnet-03"
+            subnet_ip                    = "10.10.30.0/24"
+            subnet_region                = "us-west1"
+            subnet_flow_logs             = "true"
+            subnet_flow_logs_interval    = "INTERVAL_10_MIN"
+            subnet_flow_logs_sampling    = 0.7
+            subnet_flow_logs_metadata    = "INCLUDE_ALL_METADATA"
+            subnet_flow_logs_filter_expr = "true"
         }
     ]
 
@@ -88,3 +89,4 @@ The subnets list contains maps, where each object represents a subnet. Each map 
 | subnet\_flow\_logs\_interval | If subnet\_flow\_logs is true, sets the aggregation interval for collecting flow logs                           | string |    `"INTERVAL_5_SEC"`    |    no    |
 | subnet\_flow\_logs\_sampling | If subnet\_flow\_logs is true, set the sampling rate of VPC flow logs within the subnetwork                     | string |         `"0.5"`          |    no    |
 | subnet\_flow\_logs\_metadata | If subnet\_flow\_logs is true, configures whether metadata fields should be added to the reported VPC flow logs | string | `"INCLUDE_ALL_METADATA"` |    no    |
+| subnet\_flow\_logs\_filter_expr | Export filter used to define which VPC flow logs should be logged, as as CEL expression. See https://cloud.google.com/vpc/docs/flow-logs#filtering for details on how to format this field  | string | `"true"` |    no    |

--- a/modules/subnets/README.md
+++ b/modules/subnets/README.md
@@ -89,4 +89,4 @@ The subnets list contains maps, where each object represents a subnet. Each map 
 | subnet\_flow\_logs\_interval | If subnet\_flow\_logs is true, sets the aggregation interval for collecting flow logs                           | string |    `"INTERVAL_5_SEC"`    |    no    |
 | subnet\_flow\_logs\_sampling | If subnet\_flow\_logs is true, set the sampling rate of VPC flow logs within the subnetwork                     | string |         `"0.5"`          |    no    |
 | subnet\_flow\_logs\_metadata | If subnet\_flow\_logs is true, configures whether metadata fields should be added to the reported VPC flow logs | string | `"INCLUDE_ALL_METADATA"` |    no    |
-| subnet\_flow\_logs\_filter_expr | Export filter used to define which VPC flow logs should be logged, as as CEL expression. See https://cloud.google.com/vpc/docs/flow-logs#filtering for details on how to format this field  | string | `"true"` |    no    |
+| subnet\_flow\_logs\_filter_expr | Export filter defining which VPC flow logs should be logged, see https://cloud.google.com/vpc/docs/flow-logs#filtering for formatting details  | string | `"true"` |    no    |

--- a/modules/subnets/main.tf
+++ b/modules/subnets/main.tf
@@ -36,12 +36,15 @@ resource "google_compute_subnetwork" "subnetwork" {
       aggregation_interval = lookup(each.value, "subnet_flow_logs_interval", "INTERVAL_5_SEC")
       flow_sampling        = lookup(each.value, "subnet_flow_logs_sampling", "0.5")
       metadata             = lookup(each.value, "subnet_flow_logs_metadata", "INCLUDE_ALL_METADATA")
-      //filter_expr          = lookup(each.value, "subnet_flow_logs_filter", "true")
+      // New
+      filter_expr = lookup(each.value, "subnet_flow_logs_filter", "true")
     }] : []
     content {
       aggregation_interval = log_config.value.aggregation_interval
       flow_sampling        = log_config.value.flow_sampling
       metadata             = log_config.value.metadata
+      // New
+      filter_expr = log_config.value.filter_expr
     }
   }
   network     = var.network_name

--- a/modules/subnets/main.tf
+++ b/modules/subnets/main.tf
@@ -36,15 +36,13 @@ resource "google_compute_subnetwork" "subnetwork" {
       aggregation_interval = lookup(each.value, "subnet_flow_logs_interval", "INTERVAL_5_SEC")
       flow_sampling        = lookup(each.value, "subnet_flow_logs_sampling", "0.5")
       metadata             = lookup(each.value, "subnet_flow_logs_metadata", "INCLUDE_ALL_METADATA")
-      // New
-      filter_expr = lookup(each.value, "subnet_flow_logs_filter", "true")
+      filter_expr          = lookup(each.value, "subnet_flow_logs_filter", "true")
     }] : []
     content {
       aggregation_interval = log_config.value.aggregation_interval
       flow_sampling        = log_config.value.flow_sampling
       metadata             = log_config.value.metadata
-      // New
-      filter_expr = log_config.value.filter_expr
+      filter_expr          = log_config.value.filter_expr
     }
   }
   network     = var.network_name

--- a/modules/subnets/main.tf
+++ b/modules/subnets/main.tf
@@ -36,6 +36,7 @@ resource "google_compute_subnetwork" "subnetwork" {
       aggregation_interval = lookup(each.value, "subnet_flow_logs_interval", "INTERVAL_5_SEC")
       flow_sampling        = lookup(each.value, "subnet_flow_logs_sampling", "0.5")
       metadata             = lookup(each.value, "subnet_flow_logs_metadata", "INCLUDE_ALL_METADATA")
+      //filter_expr          = lookup(each.value, "subnet_flow_logs_filter", "true")
     }] : []
     content {
       aggregation_interval = log_config.value.aggregation_interval

--- a/test/integration/simple_project/simple_project_test.go
+++ b/test/integration/simple_project/simple_project_test.go
@@ -48,7 +48,7 @@ func TestSimpleProject(t *testing.T) {
 			subnet3 := gcloud.Run(t, "compute networks subnets describe subnet-03", gcOpts)
 			assert.Equal("10.10.30.0/24", subnet3.Get("ipCidrRange").String(), "should have the right CIDR")
 			assert.False(subnet3.Get("privateIpGoogleAccess").Bool(), "should not have Private Google Access")
-			expectedLogConfig = `{"aggregationInterval": "INTERVAL_10_MIN","enable": true,"filterExpr": "true","flowSampling": 0.7,"metadata": "INCLUDE_ALL_METADATA"}`
+			expectedLogConfig = `{"aggregationInterval": "INTERVAL_10_MIN","enable": true,"filterExpr": "false","flowSampling": 0.7,"metadata": "INCLUDE_ALL_METADATA"}`
 			assert.JSONEq(expectedLogConfig, subnet3.Get("logConfig").String(), "log config should be correct")
 		})
 	net.Test()


### PR DESCRIPTION
This change added filter_expr control for log_config inside subnets module to address the following issue:
https://github.com/terraform-google-modules/terraform-google-network/issues/353

Changed simple_project test to set a non-default value to filter_expr, updated documentation manually and updated integration test to reflect new non-default value