### PR TITLE
fix: Prevent recreation of serverless connector

### DIFF
--- a/modules/vpc-serverless-connector-beta/main.tf
+++ b/modules/vpc-serverless-connector-beta/main.tf
@@ -35,4 +35,10 @@ resource "google_vpc_access_connector" "connector_beta" {
   min_instances  = lookup(each.value, "min_instances", null)
   max_instances  = lookup(each.value, "max_instances", null)
   max_throughput = lookup(each.value, "max_throughput", null)
+    
+  lifecycle {
+    ignore_changes = [
+      network,
+    ]
+  }
 }

--- a/modules/vpc-serverless-connector-beta/main.tf
+++ b/modules/vpc-serverless-connector-beta/main.tf
@@ -36,9 +36,10 @@ resource "google_vpc_access_connector" "connector_beta" {
   max_instances  = lookup(each.value, "max_instances", null)
   max_throughput = lookup(each.value, "max_throughput", null)
     
+  # REF: https://github.com/hashicorp/terraform-provider-google/issues/11304
   lifecycle {
     ignore_changes = [
-      network,
+      network
     ]
   }
 }

--- a/modules/vpc-serverless-connector-beta/main.tf
+++ b/modules/vpc-serverless-connector-beta/main.tf
@@ -35,7 +35,7 @@ resource "google_vpc_access_connector" "connector_beta" {
   min_instances  = lookup(each.value, "min_instances", null)
   max_instances  = lookup(each.value, "max_instances", null)
   max_throughput = lookup(each.value, "max_throughput", null)
-    
+
   # REF: https://github.com/hashicorp/terraform-provider-google/issues/11304
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
Been noticing this issue: https://github.com/hashicorp/terraform-provider-google/issues/11304
When using this beta module; it is possible to add that line to prevent it?