### PR TITLE
Fix README.md typo

### DIFF
--- a/modules/private-service-connect/README.md
+++ b/modules/private-service-connect/README.md
@@ -16,7 +16,7 @@ Basic usage of this module is as follows:
 
 ```hcl
 module "private_service_connect" {
-  source                     = "terraform-google-modules/network/google//modules/private_service_connect"
+  source                     = "terraform-google-modules/network/google//modules/private-service-connect"
 
   project_id                 = "<PROJECT_ID>"
   network_self_link          = "<NETWORK_SELF_LINK>"


### PR DESCRIPTION
`terraform init` was failing when using the source from the README.