### PR TITLE
fix: Adds support for pulling "attributes" as well as "attributes_flat" from pulled state.

### DIFF
--- a/helpers/migrate.py
+++ b/helpers/migrate.py
@@ -304,7 +304,12 @@ class TerraformState:
         else:
             state_resource = state_resource_list[0]["instances"]
 
-        return state_resource[0]["attributes_flat"][key]
+        if "attributes_flat" in state_resource[0]:
+            return state_resource[0]["attributes_flat"][key]
+        elif "attributes" in state_resource[0]:
+            return state_resource[0]["attributes"][key]
+        else:
+            raise "Expected either `attributes_flat` or `attributes` in state resource!"
 
 
 def group_by_module(resources):

--- a/helpers/migrate.py
+++ b/helpers/migrate.py
@@ -309,7 +309,7 @@ class TerraformState:
         elif "attributes" in state_resource[0]:
             return state_resource[0]["attributes"][key]
         else:
-            raise "Expected either `attributes_flat` or `attributes` in state resource!"
+            raise "Expected `attributes_flat` or `attributes` in resource!"
 
 
 def group_by_module(resources):


### PR DESCRIPTION
Not sure if anyone might find this useful, but I ran into an issue where my state resource has the "attributes" key defined, but not "attributes_flat".  Recently updated this project tf version to `0.12`, state version appears as `4`. I'm thinking that this might just be an artifact of having really old state. At any rate, this little modification allows the script to run on my archaic state and provide migration instructions without affecting original functionality.