### PR TITLE
feat: Add IPv6 ULA support and document subnet ipv6 support

### DIFF
--- a/modules/subnets-beta/README.md
+++ b/modules/subnets-beta/README.md
@@ -96,3 +96,6 @@ The subnets list contains maps, where each object represents a subnet. Each map 
 | subnet\_flow\_logs\_metadata\_fields | List of metadata fields that should be added to reported logs. Can only be specified if VPC flow logs for this subnetwork is enabled and "metadata" is set to CUSTOM_METADATA.  | any | - |    no    |
 | purpose | The purpose of the subnet usage. Whether it is to be used as a regular subnet or for proxy or loadbalacing purposes, see https://cloud.google.com/vpc/docs/subnets#purpose for more details  | string | `"PRIVATE"` |    no    |
 | role | The role of the subnet when using it as a proxy or loadbalancer network. Whether it is to be used as the active or as a backup subnet, see https://cloud.google.com/load-balancing/docs/proxy-only-subnets#proxy_only_subnet_create for more details  | string |            -             |    no    |
+| enable\_ipv6\_ula | Enabled IPv6 ULA, this is a permenant change and cannot be undone! (default 'false') | `bool` | `false` | no |
+| internal\_ipv6\_range | When enabling IPv6 ULA, optionally, specify a /48 from fd20::/20 (default null) | `string` | `null` | no |
+

--- a/modules/subnets-beta/main.tf
+++ b/modules/subnets-beta/main.tf
@@ -62,8 +62,10 @@ resource "google_compute_subnetwork" "subnetwork" {
     var.secondary_ranges[each.value.subnet_name][i]
   ]
 
-  purpose = lookup(each.value, "purpose", null)
-  role    = lookup(each.value, "role", null)
+  purpose          = lookup(each.value, "purpose", null)
+  role             = lookup(each.value, "role", null)
+  stack_type       = lookup(each.value, "stack", null)
+  ipv6_access_type = lookup(each.value, "ipv6_type", null)
 
   depends_on = [var.module_depends_on]
 }

--- a/modules/subnets/README.md
+++ b/modules/subnets/README.md
@@ -95,3 +95,5 @@ The subnets list contains maps, where each object represents a subnet. Each map 
 | subnet\_flow\_logs\_metadata\_fields | List of metadata fields that should be added to reported logs. Can only be specified if VPC flow logs for this subnetwork is enabled and "metadata" is set to CUSTOM_METADATA.  | any | - |    no    |
 | purpose | The purpose of the subnet usage. Whether it is to be used as a regular subnet or for proxy or loadbalacing purposes, see https://cloud.google.com/vpc/docs/subnets#purpose for more details  | string | `"PRIVATE"` |    no    |
 | role | The role of the subnet when using it as a proxy or loadbalancer network. Whether it is to be used as the active or as a backup subnet, see https://cloud.google.com/load-balancing/docs/proxy-only-subnets#proxy_only_subnet_create for more details  | string |            -             |    no    |
+| stack | `IPV4_ONLY` or `IPV4_IPV6` for dual-stack networking | string | - | no |
+| ipv6\_type | `INTERNAL` or `EXTERNAL`. `INTERNAL` requires ULA be enabled on the VPC | string | - | no |

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -31,6 +31,8 @@ module "vpc" {
 | auto\_create\_subnetworks | When set to true, the network is created in 'auto subnet mode' and it will create a subnet for each region automatically across the 10.128.0.0/9 address range. When set to false, the network is created in 'custom subnet mode' so the user can explicitly connect subnetwork resources. | `bool` | `false` | no |
 | delete\_default\_internet\_gateway\_routes | If set, ensure that all routes within the network specified whose names begin with 'default-route' and with a next hop of 'default-internet-gateway' are deleted | `bool` | `false` | no |
 | description | An optional description of this resource. The resource must be recreated to modify this field. | `string` | `""` | no |
+| enable\_ipv6\_ula | Enabled IPv6 ULA, this is a permenant change and cannot be undone! (default 'false') | `bool` | `false` | no |
+| internal\_ipv6\_range | When enabling IPv6 ULA, optionally, specify a /48 from fd20::/20 (default null) | `string` | `null` | no |
 | mtu | The network MTU (If set to 0, meaning MTU is unset - defaults to '1460'). Recommended values: 1460 (default for historic reasons), 1500 (Internet default), or 8896 (for Jumbo packets). Allowed are all values in the range 1300 to 8896, inclusively. | `number` | `0` | no |
 | network\_name | The name of the network being created | `string` | n/a | yes |
 | project\_id | The ID of the project where this VPC will be created | `string` | n/a | yes |

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -25,6 +25,8 @@ resource "google_compute_network" "network" {
   description                     = var.description
   delete_default_routes_on_create = var.delete_default_internet_gateway_routes
   mtu                             = var.mtu
+  enable_ula_internal_ipv6        = var.enable_ipv6_ula
+  internal_ipv6_range             = var.internal_ipv6_range
 }
 
 /******************************************

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -59,3 +59,15 @@ variable "mtu" {
   description = "The network MTU (If set to 0, meaning MTU is unset - defaults to '1460'). Recommended values: 1460 (default for historic reasons), 1500 (Internet default), or 8896 (for Jumbo packets). Allowed are all values in the range 1300 to 8896, inclusively."
   default     = 0
 }
+
+variable "enable_ipv6_ula" {
+  type        = bool
+  description = "Enabled IPv6 ULA, this is a permenant change and cannot be undone! (default 'false')"
+  default     = false
+}
+
+variable "internal_ipv6_range" {
+  type        = string
+  default     = null
+  description = "When enabling IPv6 ULA, optionally, specify a /48 from fd20::/20 (default null)"
+}


### PR DESCRIPTION
* Add support for ULA on VPC network
* Add optional ULA prefix for VPC network
* Add documentation for subnet `stack` to enable dual-stack networking
* Add documentation for IPv6 type to enable either `EXTERNAL` v6 addressing or `INTERNAL` when ULA is enabled in the VPC