### PR TITLE
feat: add metadata_fields support

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Then perform the following commands on the root folder:
 | routing\_mode | The network routing mode (default 'GLOBAL') | `string` | `"GLOBAL"` | no |
 | secondary\_ranges | Secondary ranges that will be used in some of the subnets | `map(list(object({ range_name = string, ip_cidr_range = string })))` | `{}` | no |
 | shared\_vpc\_host | Makes this project a Shared VPC host if 'true' (default 'false') | `bool` | `false` | no |
-| subnets | The list of subnets being created | `list(map(string))` | n/a | yes |
+| subnets | The list of subnets being created | <pre>list(object({<br>    subnet_name                      = string<br>    subnet_ip                        = string<br>    subnet_region                    = string<br>    subnet_private_access            = optional(string)<br>    subnet_private_ipv6_access       = optional(string)<br>    subnet_flow_logs                 = optional(string)<br>    subnet_flow_logs_interval        = optional(string)<br>    subnet_flow_logs_sampling        = optional(string)<br>    subnet_flow_logs_metadata        = optional(string)<br>    subnet_flow_logs_filter          = optional(string)<br>    subnet_flow_logs_metadata_fields = optional(list(string))<br>    description                      = optional(string)<br>  }))</pre> | n/a | yes |
 
 ## Outputs
 

--- a/codelabs/simple/README.md
+++ b/codelabs/simple/README.md
@@ -1,3 +1,16 @@
 # Networking Codelab
 
 The Terraform configuration in this directory is used for a [simple codelab](https://codelabs.developers.google.com/codelabs/hashicorp-terraform-networking/index.html#0).
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| ip | n/a |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/submodule_svpc_access/README.md
+++ b/examples/submodule_svpc_access/README.md
@@ -23,6 +23,6 @@ Subnet-level access in this example is only granted to the default GCE service a
 
 ## Outputs
 
-No output.
+No outputs.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -151,7 +151,7 @@ spec:
     required: false
   - name: subnets
     description: The list of subnets being created
-    type: list(map(string))
+    type: list(object({subnet_name = string, subnet_ip = string, subnet_region = string, subnet_private_access = optional(string), subnet_private_ipv6_access = optional(string), subnet_flow_logs = optional(string), subnet_flow_logs_interval = optional(string), subnet_flow_logs_sampling = optional(string), subnet_flow_logs_metadata = optional(string), subnet_flow_logs_filter = optional(string), subnet_flow_logs_metadata_fields = optional(list(string)), description = optional(string)}))
     required: true
   outputs:
   - name: network

--- a/modules/subnets-beta/README.md
+++ b/modules/subnets-beta/README.md
@@ -68,7 +68,7 @@ module "vpc" {
 | network\_name | The name of the network where subnets will be created | `string` | n/a | yes |
 | project\_id | The ID of the project where subnets will be created | `string` | n/a | yes |
 | secondary\_ranges | Secondary ranges that will be used in some of the subnets | `map(list(object({ range_name = string, ip_cidr_range = string })))` | `{}` | no |
-| subnets | The list of subnets being created | `list(map(string))` | n/a | yes |
+| subnets | The list of subnets being created | <pre>list(object({<br>    subnet_name                      = string<br>    subnet_ip                        = string<br>    subnet_region                    = string<br>    subnet_private_access            = optional(string)<br>    subnet_private_ipv6_access       = optional(string)<br>    subnet_flow_logs                 = optional(string)<br>    subnet_flow_logs_interval        = optional(string, "INTERVAL_5_SEC")<br>    subnet_flow_logs_sampling        = optional(string, "0.5")<br>    subnet_flow_logs_metadata        = optional(string, "INCLUDE_ALL_METADATA")<br>    subnet_flow_logs_filter          = optional(string, "true")<br>    subnet_flow_logs_metadata_fields = optional(list(string), [])<br>    description                      = optional(string)<br>  }))</pre> | n/a | yes |
 
 ## Outputs
 
@@ -93,5 +93,6 @@ The subnets list contains maps, where each object represents a subnet. Each map 
 | subnet\_flow\_logs\_sampling | If subnet\_flow\_logs is true, set the sampling rate of VPC flow logs within the subnetwork                     | string |         `"0.5"`          |    no    |
 | subnet\_flow\_logs\_metadata | If subnet\_flow\_logs is true, configures whether metadata fields should be added to the reported VPC flow logs | string | `"INCLUDE_ALL_METADATA"` |    no    |
 | subnet\_flow\_logs\_filter_expr | Export filter defining which VPC flow logs should be logged, see https://cloud.google.com/vpc/docs/flow-logs#filtering for formatting details  | string | `"true"` |    no    |
+| subnet\_flow\_logs\_metadata\_fields | List of metadata fields that should be added to reported logs. Can only be specified if VPC flow logs for this subnetwork is enabled and "metadata" is set to CUSTOM_METADATA.  | any | - |    no    |
 | purpose | The purpose of the subnet usage. Whether it is to be used as a regular subnet or for proxy or loadbalacing purposes, see https://cloud.google.com/vpc/docs/subnets#purpose for more details  | string | `"PRIVATE"` |    no    |
 | role | The role of the subnet when using it as a proxy or loadbalancer network. Whether it is to be used as the active or as a backup subnet, see https://cloud.google.com/load-balancing/docs/proxy-only-subnets#proxy_only_subnet_create for more details  | string |            -             |    no    |

--- a/modules/subnets-beta/main.tf
+++ b/modules/subnets-beta/main.tf
@@ -33,17 +33,19 @@ resource "google_compute_subnetwork" "subnetwork" {
   region                   = each.value.subnet_region
   private_ip_google_access = lookup(each.value, "subnet_private_access", "false")
   dynamic "log_config" {
-    for_each = lookup(each.value, "subnet_flow_logs", false) ? [{
-      aggregation_interval = lookup(each.value, "subnet_flow_logs_interval", "INTERVAL_5_SEC")
-      flow_sampling        = lookup(each.value, "subnet_flow_logs_sampling", "0.5")
-      metadata             = lookup(each.value, "subnet_flow_logs_metadata", "INCLUDE_ALL_METADATA")
-      filter_expr          = lookup(each.value, "subnet_flow_logs_filter", "true")
+    for_each = coalesce(lookup(each.value, "subnet_flow_logs", null), false) ? [{
+      aggregation_interval = each.value.subnet_flow_logs_interval
+      flow_sampling        = each.value.subnet_flow_logs_sampling
+      metadata             = each.value.subnet_flow_logs_metadata
+      filter_expr          = each.value.subnet_flow_logs_filter
+      metadata_fields      = each.value.subnet_flow_logs_metadata_fields
     }] : []
     content {
       aggregation_interval = log_config.value.aggregation_interval
       flow_sampling        = log_config.value.flow_sampling
       metadata             = log_config.value.metadata
       filter_expr          = log_config.value.filter_expr
+      metadata_fields      = log_config.value.metadata_fields
     }
   }
   network     = var.network_name

--- a/modules/subnets-beta/metadata.yaml
+++ b/modules/subnets-beta/metadata.yaml
@@ -93,7 +93,7 @@ spec:
     required: false
   - name: subnets
     description: The list of subnets being created
-    type: list(map(string))
+    type: list(object({subnet_name = string, subnet_ip = string, subnet_region = string, subnet_private_access = optional(string), subnet_private_ipv6_access = optional(string), subnet_flow_logs = optional(string), subnet_flow_logs_interval = optional(string), subnet_flow_logs_sampling = optional(string), subnet_flow_logs_metadata = optional(string), subnet_flow_logs_filter = optional(string), subnet_flow_logs_metadata_fields = optional(list(string)), description = optional(string)}))
     required: true
   outputs:
   - name: subnets

--- a/modules/subnets-beta/variables.tf
+++ b/modules/subnets-beta/variables.tf
@@ -25,7 +25,20 @@ variable "network_name" {
 }
 
 variable "subnets" {
-  type        = list(map(string))
+  type = list(object({
+    subnet_name                      = string
+    subnet_ip                        = string
+    subnet_region                    = string
+    subnet_private_access            = optional(string)
+    subnet_private_ipv6_access       = optional(string)
+    subnet_flow_logs                 = optional(string)
+    subnet_flow_logs_interval        = optional(string, "INTERVAL_5_SEC")
+    subnet_flow_logs_sampling        = optional(string, "0.5")
+    subnet_flow_logs_metadata        = optional(string, "INCLUDE_ALL_METADATA")
+    subnet_flow_logs_filter          = optional(string, "true")
+    subnet_flow_logs_metadata_fields = optional(list(string), [])
+    description                      = optional(string)
+  }))
   description = "The list of subnets being created"
 }
 

--- a/modules/subnets/README.md
+++ b/modules/subnets/README.md
@@ -67,7 +67,7 @@ module "vpc" {
 | network\_name | The name of the network where subnets will be created | `string` | n/a | yes |
 | project\_id | The ID of the project where subnets will be created | `string` | n/a | yes |
 | secondary\_ranges | Secondary ranges that will be used in some of the subnets | `map(list(object({ range_name = string, ip_cidr_range = string })))` | `{}` | no |
-| subnets | The list of subnets being created | `list(map(string))` | n/a | yes |
+| subnets | The list of subnets being created | <pre>list(object({<br>    subnet_name                      = string<br>    subnet_ip                        = string<br>    subnet_region                    = string<br>    subnet_private_access            = optional(string)<br>    subnet_private_ipv6_access       = optional(string)<br>    subnet_flow_logs                 = optional(string)<br>    subnet_flow_logs_interval        = optional(string, "INTERVAL_5_SEC")<br>    subnet_flow_logs_sampling        = optional(string, "0.5")<br>    subnet_flow_logs_metadata        = optional(string, "INCLUDE_ALL_METADATA")<br>    subnet_flow_logs_filter          = optional(string, "true")<br>    subnet_flow_logs_metadata_fields = optional(list(string), [])<br>    description                      = optional(string)<br>  }))</pre> | n/a | yes |
 
 ## Outputs
 
@@ -92,5 +92,6 @@ The subnets list contains maps, where each object represents a subnet. Each map 
 | subnet\_flow\_logs\_sampling | If subnet\_flow\_logs is true, set the sampling rate of VPC flow logs within the subnetwork                     | string |         `"0.5"`          |    no    |
 | subnet\_flow\_logs\_metadata | If subnet\_flow\_logs is true, configures whether metadata fields should be added to the reported VPC flow logs | string | `"INCLUDE_ALL_METADATA"` |    no    |
 | subnet\_flow\_logs\_filter_expr | Export filter defining which VPC flow logs should be logged, see https://cloud.google.com/vpc/docs/flow-logs#filtering for formatting details  | string | `"true"` |    no    |
+| subnet\_flow\_logs\_metadata\_fields | List of metadata fields that should be added to reported logs. Can only be specified if VPC flow logs for this subnetwork is enabled and "metadata" is set to CUSTOM_METADATA.  | any | - |    no    |
 | purpose | The purpose of the subnet usage. Whether it is to be used as a regular subnet or for proxy or loadbalacing purposes, see https://cloud.google.com/vpc/docs/subnets#purpose for more details  | string | `"PRIVATE"` |    no    |
 | role | The role of the subnet when using it as a proxy or loadbalancer network. Whether it is to be used as the active or as a backup subnet, see https://cloud.google.com/load-balancing/docs/proxy-only-subnets#proxy_only_subnet_create for more details  | string |            -             |    no    |

--- a/modules/subnets/main.tf
+++ b/modules/subnets/main.tf
@@ -33,17 +33,19 @@ resource "google_compute_subnetwork" "subnetwork" {
   private_ip_google_access   = lookup(each.value, "subnet_private_access", "false")
   private_ipv6_google_access = lookup(each.value, "subnet_private_ipv6_access", null)
   dynamic "log_config" {
-    for_each = lookup(each.value, "subnet_flow_logs", false) ? [{
-      aggregation_interval = lookup(each.value, "subnet_flow_logs_interval", "INTERVAL_5_SEC")
-      flow_sampling        = lookup(each.value, "subnet_flow_logs_sampling", "0.5")
-      metadata             = lookup(each.value, "subnet_flow_logs_metadata", "INCLUDE_ALL_METADATA")
-      filter_expr          = lookup(each.value, "subnet_flow_logs_filter", "true")
+    for_each = coalesce(lookup(each.value, "subnet_flow_logs", null), false) ? [{
+      aggregation_interval = each.value.subnet_flow_logs_interval
+      flow_sampling        = each.value.subnet_flow_logs_sampling
+      metadata             = each.value.subnet_flow_logs_metadata
+      filter_expr          = each.value.subnet_flow_logs_filter
+      metadata_fields      = each.value.subnet_flow_logs_metadata_fields
     }] : []
     content {
       aggregation_interval = log_config.value.aggregation_interval
       flow_sampling        = log_config.value.flow_sampling
       metadata             = log_config.value.metadata
       filter_expr          = log_config.value.filter_expr
+      metadata_fields      = log_config.value.metadata_fields
     }
   }
   network     = var.network_name

--- a/modules/subnets/metadata.yaml
+++ b/modules/subnets/metadata.yaml
@@ -88,7 +88,7 @@ spec:
     required: false
   - name: subnets
     description: The list of subnets being created
-    type: list(map(string))
+    type: list(object({subnet_name = string, subnet_ip = string, subnet_region = string, subnet_private_access = optional(string), subnet_private_ipv6_access = optional(string), subnet_flow_logs = optional(string), subnet_flow_logs_interval = optional(string), subnet_flow_logs_sampling = optional(string), subnet_flow_logs_metadata = optional(string), subnet_flow_logs_filter = optional(string), subnet_flow_logs_metadata_fields = optional(list(string)), description = optional(string)}))
     required: true
   outputs:
   - name: subnets

--- a/modules/subnets/variables.tf
+++ b/modules/subnets/variables.tf
@@ -25,7 +25,20 @@ variable "network_name" {
 }
 
 variable "subnets" {
-  type        = list(map(string))
+  type = list(object({
+    subnet_name                      = string
+    subnet_ip                        = string
+    subnet_region                    = string
+    subnet_private_access            = optional(string)
+    subnet_private_ipv6_access       = optional(string)
+    subnet_flow_logs                 = optional(string)
+    subnet_flow_logs_interval        = optional(string, "INTERVAL_5_SEC")
+    subnet_flow_logs_sampling        = optional(string, "0.5")
+    subnet_flow_logs_metadata        = optional(string, "INCLUDE_ALL_METADATA")
+    subnet_flow_logs_filter          = optional(string, "true")
+    subnet_flow_logs_metadata_fields = optional(list(string), [])
+    description                      = optional(string)
+  }))
   description = "The list of subnets being created"
 }
 

--- a/test/setup/README.md
+++ b/test/setup/README.md
@@ -33,3 +33,21 @@ integration tests from your machine.
 Alternatively, to run the integration tests directly from the Docker
 container used by the module's CI pipeline, perform the above steps and then
 run the `make test_integration_docker` target
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| billing\_account | The billing account id associated with the project, e.g. XXXXXX-YYYYYY-ZZZZZZ | `any` | n/a | yes |
+| folder\_id | The folder to deploy in | `any` | n/a | yes |
+| org\_id | The numeric organization id | `any` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| project\_id | n/a |
+| sa\_key | n/a |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/variables.tf
+++ b/variables.tf
@@ -37,7 +37,20 @@ variable "shared_vpc_host" {
 }
 
 variable "subnets" {
-  type        = list(map(string))
+  type = list(object({
+    subnet_name                      = string
+    subnet_ip                        = string
+    subnet_region                    = string
+    subnet_private_access            = optional(string)
+    subnet_private_ipv6_access       = optional(string)
+    subnet_flow_logs                 = optional(string)
+    subnet_flow_logs_interval        = optional(string)
+    subnet_flow_logs_sampling        = optional(string)
+    subnet_flow_logs_metadata        = optional(string)
+    subnet_flow_logs_filter          = optional(string)
+    subnet_flow_logs_metadata_fields = optional(list(string))
+    description                      = optional(string)
+  }))
   description = "The list of subnets being created"
 }
 


### PR DESCRIPTION
- Add `metadata_fields` to the `log_config` block of subnets submodule
- Update documentation
- Terraform resource: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork.html#metadata_fields
- Ref #239

Note:
- Had to change `subnets` variable type from `list(map(string))` to `list(object{...})`, to allow heterogeneous types.