### PR TITLE
feat: update module to remove deprecated rules field in firewall module

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Then perform the following commands on the root folder:
 
 | Name | Description |
 |------|-------------|
+| egress\_rules | n/a |
+| ingress\_rules | n/a |
 | network | The created network |
 | network\_id | The ID of the VPC being created |
 | network\_name | The name of the VPC being created |

--- a/main.tf
+++ b/main.tf
@@ -55,13 +55,14 @@ module "routes" {
 	Firewall rules
  *****************************************/
 locals {
-  rules = [
+  ingress_rules = [
     for f in var.firewall_rules : {
       name                    = f.name
       direction               = f.direction
       priority                = lookup(f, "priority", null)
       description             = lookup(f, "description", null)
-      ranges                  = lookup(f, "ranges", null)
+      source_ranges           = lookup(f, "source_ranges", null)
+      destination_ranges      = lookup(f, "destination_ranges", null)
       source_tags             = lookup(f, "source_tags", null)
       source_service_accounts = lookup(f, "source_service_accounts", null)
       target_tags             = lookup(f, "target_tags", null)
@@ -69,13 +70,31 @@ locals {
       allow                   = lookup(f, "allow", [])
       deny                    = lookup(f, "deny", [])
       log_config              = lookup(f, "log_config", null)
-    }
+    } if f.direction == "INGRESS"
+  ]
+  egress_rules = [
+    for f in var.firewall_rules : {
+      name                    = f.name
+      direction               = f.direction
+      priority                = lookup(f, "priority", null)
+      description             = lookup(f, "description", null)
+      source_ranges           = lookup(f, "source_ranges", null)
+      destination_ranges      = lookup(f, "destination_ranges", null)
+      source_tags             = lookup(f, "source_tags", null)
+      source_service_accounts = lookup(f, "source_service_accounts", null)
+      target_tags             = lookup(f, "target_tags", null)
+      target_service_accounts = lookup(f, "target_service_accounts", null)
+      allow                   = lookup(f, "allow", [])
+      deny                    = lookup(f, "deny", [])
+      log_config              = lookup(f, "log_config", null)
+    } if f.direction == "EGRESS"
   ]
 }
 
 module "firewall_rules" {
-  source       = "./modules/firewall-rules"
-  project_id   = var.project_id
-  network_name = module.vpc.network_name
-  rules        = local.rules
+  source        = "./modules/firewall-rules"
+  project_id    = var.project_id
+  network_name  = module.vpc.network_name
+  ingress_rules = local.ingress_rules
+  egress_rules  = local.egress_rules
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -88,3 +88,11 @@ output "route_names" {
   value       = [for route in module.routes.routes : route.name]
   description = "The route names associated with this VPC"
 }
+
+
+output "ingress_rules" {
+  value = local.ingress_rules
+}
+output "egress_rules" {
+  value = local.egress_rules
+}


### PR DESCRIPTION
* remove usage of `rules` variable in network module for the firewall part to use the newest variables: `ingress_rules` and `egress_rules`

This PR will contain a breaking changes and users will have to replace the `rules` field in the `firewall_rules` variable to remove `ranges` property and replace it with `source_ranges` or `destination_ranges`