### PR TITLE
feat: add stack type to peering module

### DIFF
--- a/modules/network-peering/README.md
+++ b/modules/network-peering/README.md
@@ -56,6 +56,7 @@ module "peering-a-c" {
 | module\_depends\_on | List of modules or resources this module depends on. | `list(any)` | `[]` | no |
 | peer\_network | Resource link of the peer network. | `string` | n/a | yes |
 | prefix | Name prefix for the network peerings | `string` | `"network-peering"` | no |
+| stack\_type | Which IP version(s) of traffic and routes are allowed to be imported or exported between peer networks. Possible values: ["IPV4\_ONLY", "IPV4\_IPV6"]. | `string` | `"IPV4_ONLY"` | no |
 
 ## Outputs
 

--- a/modules/network-peering/main.tf
+++ b/modules/network-peering/main.tf
@@ -42,6 +42,8 @@ resource "google_compute_network_peering" "local_network_peering" {
   export_subnet_routes_with_public_ip = var.export_local_subnet_routes_with_public_ip
   import_subnet_routes_with_public_ip = var.export_peer_subnet_routes_with_public_ip
 
+  stack_type = var.stack_type
+
   depends_on = [null_resource.module_depends_on]
 }
 
@@ -55,6 +57,8 @@ resource "google_compute_network_peering" "peer_network_peering" {
 
   export_subnet_routes_with_public_ip = var.export_peer_subnet_routes_with_public_ip
   import_subnet_routes_with_public_ip = var.export_local_subnet_routes_with_public_ip
+
+  stack_type = var.stack_type
 
   depends_on = [null_resource.module_depends_on, google_compute_network_peering.local_network_peering]
 }

--- a/modules/network-peering/variables.tf
+++ b/modules/network-peering/variables.tf
@@ -59,3 +59,9 @@ variable "module_depends_on" {
   type        = list(any)
   default     = []
 }
+
+variable "stack_type" {
+  description = "Which IP version(s) of traffic and routes are allowed to be imported or exported between peer networks. Possible values: [\"IPV4_ONLY\", \"IPV4_IPV6\"]."
+  type        = string
+  default     = "IPV4_ONLY"
+}

--- a/modules/network-peering/versions.tf
+++ b/modules/network-peering/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "<5.0,>= 4.65"
+      version = ">= 4.65, <5.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "<5.0,>= 4.65"
+      version = ">= 4.65, <5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/network-peering/versions.tf
+++ b/modules/network-peering/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "<5.0,>= 2.12"
+      version = "<5.0,>= 4.65"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "<5.0,>= 2.12"
+      version = "<5.0,>= 4.65"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Add `stack_type` variable to the `network-peering` module.

The `stack_type` value will be added to `local` and `peer` resources.

[Link](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network_peering#stack_type) to the `stack_type` field in google provider.