### PR TITLE
feat: Add service_directory_registrations: namespace and service_directory_region

### DIFF
--- a/docs/upgrading_to_v10.0.0.md
+++ b/docs/upgrading_to_v10.0.0.md
@@ -1,0 +1,5 @@
+# Upgrading to v10.0.0
+
+The v10.0 release contains backwards-incompatible changes.
+
+This update requires upgrading the minimum provider version of `hashicorp/google` from `3.50` to `5.8` and `hashicorp/google-beta` from `3.50` to `5.8`.

--- a/modules/private-service-connect/README.md
+++ b/modules/private-service-connect/README.md
@@ -57,6 +57,8 @@ If you have a firewall rule blocking egress traffic, you will need to configure 
 | private\_service\_connect\_ip | The internal IP to be used for the private service connect. | `string` | n/a | yes |
 | private\_service\_connect\_name | Private Service Connect endpoint name. Defaults to `global-psconnect-ip` | `string` | `"global-psconnect-ip"` | no |
 | project\_id | Project ID for Private Service Connect. | `string` | n/a | yes |
+| service\_directory\_namespace | Service Directory namespace to register the forwarding rule under. | `string` | `null` | no |
+| service\_directory\_region | Service Directory region to register this global forwarding rule under. Defaults to `us-central1` if not defined. | `string` | `null` | no |
 
 ## Outputs
 

--- a/modules/private-service-connect/main.tf
+++ b/modules/private-service-connect/main.tf
@@ -38,4 +38,13 @@ resource "google_compute_global_forwarding_rule" "forwarding_rule_private_servic
   network               = var.network_self_link
   ip_address            = google_compute_global_address.private_service_connect.id
   load_balancing_scheme = ""
+
+  dynamic "service_directory_registrations" {
+    for_each = var.service_directory_namespace != null || var.service_directory_region != null ? [1] : []
+
+    content {
+      namespace                = var.service_directory_namespace
+      service_directory_region = var.service_directory_region
+    }
+  }
 }

--- a/modules/private-service-connect/variables.tf
+++ b/modules/private-service-connect/variables.tf
@@ -56,3 +56,15 @@ variable "forwarding_rule_target" {
     error_message = "For forwarding_rule_target only `all-apis` and `vpc-sc` are valid."
   }
 }
+
+variable "service_directory_namespace" {
+  description = "Service Directory namespace to register the forwarding rule under."
+  type        = string
+  default     = null
+}
+
+variable "service_directory_region" {
+  description = "Service Directory region to register this global forwarding rule under. Defaults to `us-central1` if not defined."
+  type        = string
+  default     = null
+}

--- a/modules/private-service-connect/versions.tf
+++ b/modules/private-service-connect/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.50, < 6"
+      version = ">= 5.8, < 6"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.50, < 6"
+      version = ">= 5.8, < 6"
     }
   }
 


### PR DESCRIPTION
Hi, I would propose to add optional variable of `project_region` for this module.

The idea is to allow specifying custom, not in us-central1, namespace link.