### PR TITLE
feat: allow enabling global access for PSC endpoints

### DIFF
--- a/modules/private-service-connect/README.md
+++ b/modules/private-service-connect/README.md
@@ -57,6 +57,7 @@ If you have a firewall rule blocking egress traffic, you will need to configure 
 | private\_service\_connect\_ip | The internal IP to be used for the private service connect. | `string` | n/a | yes |
 | private\_service\_connect\_name | Private Service Connect endpoint name. Defaults to `global-psconnect-ip` | `string` | `"global-psconnect-ip"` | no |
 | project\_id | Project ID for Private Service Connect. | `string` | n/a | yes |
+| psc\_global\_access | This is used in PSC consumer ForwardingRule to control whether the PSC endpoint can be accessed from another region. Defaults to `false` | `bool` | `false` | no |
 | service\_directory\_namespace | Service Directory namespace to register the forwarding rule under. | `string` | `null` | no |
 | service\_directory\_region | Service Directory region to register this global forwarding rule under. Defaults to `us-central1` if not defined. | `string` | `null` | no |
 

--- a/modules/private-service-connect/main.tf
+++ b/modules/private-service-connect/main.tf
@@ -31,13 +31,14 @@ resource "google_compute_global_address" "private_service_connect" {
 }
 
 resource "google_compute_global_forwarding_rule" "forwarding_rule_private_service_connect" {
-  provider              = google-beta
-  project               = var.project_id
-  name                  = var.forwarding_rule_name
-  target                = var.forwarding_rule_target
-  network               = var.network_self_link
-  ip_address            = google_compute_global_address.private_service_connect.id
-  load_balancing_scheme = ""
+  provider                = google-beta
+  project                 = var.project_id
+  name                    = var.forwarding_rule_name
+  target                  = var.forwarding_rule_target
+  network                 = var.network_self_link
+  ip_address              = google_compute_global_address.private_service_connect.id
+  load_balancing_scheme   = ""
+  allow_psc_global_access = var.psc_global_access
 
   dynamic "service_directory_registrations" {
     for_each = var.service_directory_namespace != null || var.service_directory_region != null ? [1] : []

--- a/modules/private-service-connect/variables.tf
+++ b/modules/private-service-connect/variables.tf
@@ -68,3 +68,9 @@ variable "service_directory_region" {
   type        = string
   default     = null
 }
+
+variable "psc_global_access" {
+  description = "This is used in PSC consumer ForwardingRule to control whether the PSC endpoint can be accessed from another region. Defaults to `false`"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Adds the ability to allow specifying the PSC endpoint as global or not. See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_forwarding_rule#allow_psc_global_access 