### PR TITLE
feat!: Add network_profile setting to network, update network resource provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Then perform the following commands on the root folder:
 | mtu | The network MTU (If set to 0, meaning MTU is unset - defaults to '1460'). Recommended values: 1460 (default for historic reasons), 1500 (Internet default), or 8896 (for Jumbo packets). Allowed are all values in the range 1300 to 8896, inclusively. | `number` | `0` | no |
 | network\_firewall\_policy\_enforcement\_order | Set the order that Firewall Rules and Firewall Policies are evaluated. Valid values are `BEFORE_CLASSIC_FIREWALL` and `AFTER_CLASSIC_FIREWALL`. (default null or equivalent to `AFTER_CLASSIC_FIREWALL`) | `string` | `null` | no |
 | network\_name | The name of the network being created | `string` | n/a | yes |
+| network\_profile | "A full or partial URL of the network profile to apply to this network.<br>This field can be set only at resource creation time. For example, the<br>following are valid URLs:<br>  * https://www.googleapis.com/compute/beta/projects/{projectId}/global/networkProfiles/{network_profile_name}<br>  * projects/{projectId}/global/networkProfiles/{network\_profile\_name} | `string` | `null` | no |
 | project\_id | The ID of the project where this VPC will be created | `string` | n/a | yes |
 | routes | List of routes being created in this VPC | `list(map(string))` | `[]` | no |
 | routing\_mode | The network routing mode (default 'GLOBAL') | `string` | `"GLOBAL"` | no |

--- a/docs/upgrading_to_v10.0.0.md
+++ b/docs/upgrading_to_v10.0.0.md
@@ -2,4 +2,4 @@
 
 The v10.0 release contains backwards-incompatible changes.
 
-This update requires upgrading the minimum provider version of `hashicorp/google` from `3.50` to `5.8` and `hashicorp/google-beta` from `3.50` to `5.8`.
+This update requires upgrading the minimum provider version of `hashicorp/google` from `3.50` to `5.8` and `hashicorp/google-beta` from `3.50` to `6.13`.

--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,7 @@ module "vpc" {
   enable_ipv6_ula                           = var.enable_ipv6_ula
   internal_ipv6_range                       = var.internal_ipv6_range
   network_firewall_policy_enforcement_order = var.network_firewall_policy_enforcement_order
+  network_profile                           = var.network_profile
 }
 
 /******************************************

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -36,6 +36,7 @@ module "vpc" {
 | mtu | The network MTU (If set to 0, meaning MTU is unset - defaults to '1460'). Recommended values: 1460 (default for historic reasons), 1500 (Internet default), or 8896 (for Jumbo packets). Allowed are all values in the range 1300 to 8896, inclusively. | `number` | `0` | no |
 | network\_firewall\_policy\_enforcement\_order | Set the order that Firewall Rules and Firewall Policies are evaluated. Valid values are `BEFORE_CLASSIC_FIREWALL` and `AFTER_CLASSIC_FIREWALL`. (default null or equivalent to `AFTER_CLASSIC_FIREWALL`) | `string` | `null` | no |
 | network\_name | The name of the network being created | `string` | n/a | yes |
+| network\_profile | "A full or partial URL of the network profile to apply to this network.<br>This field can be set only at resource creation time. For example, the<br>following are valid URLs:<br>  * https://www.googleapis.com/compute/beta/projects/{projectId}/global/networkProfiles/{network_profile_name}<br>  * projects/{projectId}/global/networkProfiles/{network\_profile\_name} | `string` | `null` | no |
 | project\_id | The ID of the project where this VPC will be created | `string` | n/a | yes |
 | routing\_mode | The network routing mode (default 'GLOBAL') | `string` | `"GLOBAL"` | no |
 | shared\_vpc\_host | Makes this project a Shared VPC host if 'true' (default 'false') | `bool` | `false` | no |

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -18,6 +18,7 @@
 	VPC configuration
  *****************************************/
 resource "google_compute_network" "network" {
+  provider                                  = google-beta
   name                                      = var.network_name
   auto_create_subnetworks                   = var.auto_create_subnetworks
   routing_mode                              = var.routing_mode
@@ -28,6 +29,7 @@ resource "google_compute_network" "network" {
   enable_ula_internal_ipv6                  = var.enable_ipv6_ula
   internal_ipv6_range                       = var.internal_ipv6_range
   network_firewall_policy_enforcement_order = var.network_firewall_policy_enforcement_order
+  network_profile                           = var.network_profile
 }
 
 /******************************************

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -82,7 +82,7 @@ variable "network_profile" {
   type        = string
   default     = null
   description = <<-EOT
-    "A full or partial URL of the network profile to apply to this network. 
+    "A full or partial URL of the network profile to apply to this network.
     This field can be set only at resource creation time. For example, the
     following are valid URLs:
       * https://www.googleapis.com/compute/beta/projects/{projectId}/global/networkProfiles/{network_profile_name}

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -77,3 +77,15 @@ variable "network_firewall_policy_enforcement_order" {
   default     = null
   description = "Set the order that Firewall Rules and Firewall Policies are evaluated. Valid values are `BEFORE_CLASSIC_FIREWALL` and `AFTER_CLASSIC_FIREWALL`. (default null or equivalent to `AFTER_CLASSIC_FIREWALL`)"
 }
+
+variable "network_profile" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    "A full or partial URL of the network profile to apply to this network. 
+    This field can be set only at resource creation time. For example, the
+    following are valid URLs:
+      * https://www.googleapis.com/compute/beta/projects/{projectId}/global/networkProfiles/{network_profile_name}
+      * projects/{projectId}/global/networkProfiles/{network_profile_name}
+    EOT
+}

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -24,7 +24,7 @@ terraform {
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.XX, < 7" # TODO Update this once the provider is released (DO NOT MERGE)
+      version = ">= 6.13.0, < 7"
     }
   }
 

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -24,7 +24,7 @@ terraform {
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.13.0, < 7"
+      version = ">= 6.13, < 7"
     }
   }
 

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -24,7 +24,7 @@ terraform {
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.64, < 7"
+      version = ">= 6.XX, < 7" # TODO Update this once the provider is released (DO NOT MERGE)
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -204,7 +204,7 @@ variable "network_profile" {
   type        = string
   default     = null
   description = <<-EOT
-    "A full or partial URL of the network profile to apply to this network. 
+    "A full or partial URL of the network profile to apply to this network.
     This field can be set only at resource creation time. For example, the
     following are valid URLs:
       * https://www.googleapis.com/compute/beta/projects/{projectId}/global/networkProfiles/{network_profile_name}

--- a/variables.tf
+++ b/variables.tf
@@ -199,3 +199,15 @@ variable "network_firewall_policy_enforcement_order" {
   default     = null
   description = "Set the order that Firewall Rules and Firewall Policies are evaluated. Valid values are `BEFORE_CLASSIC_FIREWALL` and `AFTER_CLASSIC_FIREWALL`. (default null or equivalent to `AFTER_CLASSIC_FIREWALL`)"
 }
+
+variable "network_profile" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    "A full or partial URL of the network profile to apply to this network. 
+    This field can be set only at resource creation time. For example, the
+    following are valid URLs:
+      * https://www.googleapis.com/compute/beta/projects/{projectId}/global/networkProfiles/{network_profile_name}
+      * projects/{projectId}/global/networkProfiles/{network_profile_name}
+    EOT
+}


### PR DESCRIPTION
This PR adds the `network_profile` setting to the `google_compute_network` resource and to the top level module.  This change is necessary to enable the RDMA profiles, required for the new GPU machine types on GCP.

This is currently untested and will be updated once the `google-beta` provider with these changes has been released (expected 11/25/24).