### PR TITLE
chore: Update README.md

### DIFF
--- a/modules/vpc-serverless-connector-beta/README.md
+++ b/modules/vpc-serverless-connector-beta/README.md
@@ -23,7 +23,6 @@ module "serverless-connector" {
     machine_type    = "e2-standard-4"
     min_instances   = 2
     max_instances   = 3
-    max_throughput  = 300
   }]
 }
 ```


### PR DESCRIPTION
As per the [latest documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vpc_access_connector):

> Only one of max_throughput and max_instances can be specified. The use of max_throughput is discouraged in favor of max_instances. 

If you are using both, you will get this error: 
```
╷
│ Error: Conflicting configuration arguments
│ 
│   with module.serverless_connector.google_vpc_access_connector.connector_beta["ew4-serverless"],
│   on .terraform/modules/serverless_connector/modules/vpc-serverless-connector-beta/main.tf line 36, in resource "google_vpc_access_connector" "connector_beta":
│   36:   max_instances  = each.value.max_instances
│ 
│ "max_instances": conflicts with max_throughput
╵
╷
│ Error: Conflicting configuration arguments
│ 
│   with module.serverless_connector.google_vpc_access_connector.connector_beta["ew4-serverless"],
│   on .terraform/modules/serverless_connector/modules/vpc-serverless-connector-beta/main.tf line 37, in resource "google_vpc_access_connector" "connector_beta":
│   37:   max_throughput = each.value.max_throughput
│ 
│ "max_throughput": conflicts with max_instances
```