### PR TITLE
fix(docs): Correct bgp_best_path_selection_mode default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Then perform the following commands on the root folder:
 |------|-------------|------|---------|:--------:|
 | auto\_create\_subnetworks | When set to true, the network is created in 'auto subnet mode' and it will create a subnet for each region automatically across the 10.128.0.0/9 address range. When set to false, the network is created in 'custom subnet mode' so the user can explicitly connect subnetwork resources. | `bool` | `false` | no |
 | bgp\_always\_compare\_med | If set to true, the Cloud Router will use MED values from the peer even if the AS paths differ. Default is false. | `bool` | `false` | no |
-| bgp\_best\_path\_selection\_mode | Specifies the BGP best path selection mode. Valid values are `STANDARD` or `LEGACY`. Default is `STANDARD`. | `string` | `"LEGACY"` | no |
+| bgp\_best\_path\_selection\_mode | Specifies the BGP best path selection mode. Valid values are `STANDARD` or `LEGACY`. Default is `LEGACY`. | `string` | `"LEGACY"` | no |
 | bgp\_inter\_region\_cost | Specifies the BGP inter-region cost mode. Valid values are `DEFAULT` or `ADD_COST_TO_MED`. | `string` | `null` | no |
 | delete\_default\_internet\_gateway\_routes | If set, ensure that all routes within the network specified whose names begin with 'default-route' and with a next hop of 'default-internet-gateway' are deleted | `bool` | `false` | no |
 | description | An optional description of this resource. The resource must be recreated to modify this field. | `string` | `""` | no |

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -30,7 +30,7 @@ module "vpc" {
 |------|-------------|------|---------|:--------:|
 | auto\_create\_subnetworks | When set to true, the network is created in 'auto subnet mode' and it will create a subnet for each region automatically across the 10.128.0.0/9 address range. When set to false, the network is created in 'custom subnet mode' so the user can explicitly connect subnetwork resources. | `bool` | `false` | no |
 | bgp\_always\_compare\_med | If set to true, the Cloud Router will use MED values from the peer even if the AS paths differ. Default is false. | `bool` | `false` | no |
-| bgp\_best\_path\_selection\_mode | Specifies the BGP best path selection mode. Valid values are `STANDARD` or `LEGACY`. Default is `STANDARD`. | `string` | `"LEGACY"` | no |
+| bgp\_best\_path\_selection\_mode | Specifies the BGP best path selection mode. Valid values are `STANDARD` or `LEGACY`. Default is `LEGACY`. | `string` | `"LEGACY"` | no |
 | bgp\_inter\_region\_cost | Specifies the BGP inter-region cost mode. Valid values are `DEFAULT` or `ADD_COST_TO_MED`. | `string` | `null` | no |
 | delete\_default\_internet\_gateway\_routes | If set, ensure that all routes within the network specified whose names begin with 'default-route' and with a next hop of 'default-internet-gateway' are deleted | `bool` | `false` | no |
 | description | An optional description of this resource. The resource must be recreated to modify this field. | `string` | `""` | no |

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -98,7 +98,7 @@ variable "bgp_always_compare_med" {
 
 variable "bgp_best_path_selection_mode" {
   type        = string
-  description = "Specifies the BGP best path selection mode. Valid values are `STANDARD` or `LEGACY`. Default is `STANDARD`."
+  description = "Specifies the BGP best path selection mode. Valid values are `STANDARD` or `LEGACY`. Default is `LEGACY`."
   default     = "LEGACY"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -220,7 +220,7 @@ variable "bgp_always_compare_med" {
 
 variable "bgp_best_path_selection_mode" {
   type        = string
-  description = "Specifies the BGP best path selection mode. Valid values are `STANDARD` or `LEGACY`. Default is `STANDARD`."
+  description = "Specifies the BGP best path selection mode. Valid values are `STANDARD` or `LEGACY`. Default is `LEGACY`."
   default     = "LEGACY"
 }
 


### PR DESCRIPTION
The docs say that the default is `STANDARD` but it is `LEGACY`.

Fixup of #616, which changed the default value but missed some of the docs