### PR TITLE
fix!: remove hardcoded gcp-beta in vpc sub-module

### DIFF
--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -18,7 +18,6 @@
 	VPC configuration
  *****************************************/
 resource "google_compute_network" "network" {
-  provider                                  = google-beta
   name                                      = var.network_name
   auto_create_subnetworks                   = var.auto_create_subnetworks
   routing_mode                              = var.routing_mode


### PR DESCRIPTION
The use of google-beta was added to accommodate network_profile at the time.  It's now GA and the hard-coded beta provider causes the return of URL for nework_profile  `https://www.googleapis.com/compute/beta/projects/.......` when the actual URL from the infrastructure is  
`networkProfile: https://www.googleapis.com/compute/v1/projects` ( v1 instead of beta)
you can validate that by running gcloud compute networks describe <network>