### PR TITLE
chore: Enable metadata generation for lint tests in local setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ docker_test_integration:
 .PHONY: docker_test_lint
 docker_test_lint:
 	docker run --rm -it \
-		-e ENABLE_METADATABP=1 \
+		-e ENABLE_BPMETADATA=1 \
 		-v $(CURDIR):/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
 		/usr/local/bin/test_lint.sh


### PR DESCRIPTION
This updates the makefile to enable metadata generation for lint tests.