### PR TITLE
fix: make bgpAlwaysCompareMed and bgpInterRegionCost conditional on STANDARD mode

### DIFF
--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -30,9 +30,14 @@ resource "google_compute_network" "network" {
   internal_ipv6_range                       = var.internal_ipv6_range
   network_firewall_policy_enforcement_order = var.network_firewall_policy_enforcement_order
   network_profile                           = var.network_profile
-  bgp_always_compare_med                    = var.bgp_always_compare_med
-  bgp_best_path_selection_mode              = var.bgp_best_path_selection_mode
-  bgp_inter_region_cost                     = var.bgp_inter_region_cost
+
+  # BGP best path selection mode - always set
+  bgp_best_path_selection_mode = var.bgp_best_path_selection_mode
+
+  # BGP MED and inter-region cost - only valid with STANDARD mode
+  # GCP API rejects these fields when mode is LEGACY, even if set to false/null
+  bgp_always_compare_med = var.bgp_best_path_selection_mode == "STANDARD" ? var.bgp_always_compare_med : null
+  bgp_inter_region_cost  = var.bgp_best_path_selection_mode == "STANDARD" ? var.bgp_inter_region_cost : null
 }
 
 /******************************************


### PR DESCRIPTION
## Problem

When using the VPC module v12.0.0+ (including latest v13.0.0) with default settings (`bgp_best_path_selection_mode = "LEGACY"`), VPC creation fails with:

```
Error: Error creating Network: googleapi: Error 400:
Field bgp_always_compare_med is not supported for LEGACY BGP
Best Path Selection algorithm., badRequest
```

## Root Cause

The module unconditionally sets `bgpAlwaysCompareMed` and `bgpInterRegionCost` fields in the `google_compute_network` resource, even when `bgpBestPathSelectionMode` is `"LEGACY"` (the default).

According to [GCP's official API documentation](https://cloud.google.com/network-connectivity/docs/router/how-to/create-network-set-modes#api_1):

> **`bgpAlwaysCompareMed` is optional when `bgpBestPathSelectionMode` is `STANDARD` but must be omitted when `bgpBestPathSelectionMode` is `LEGACY`.**
>
> **When `bgpBestPathSelectionMode` is `STANDARD`, `bgpInterRegionCost` is optional but must be omitted when `bgpBestPathSelectionMode` is `LEGACY`.**

## Solution

This PR makes `bgpAlwaysCompareMed` and `bgpInterRegionCost` conditional - they are only set when `bgp_best_path_selection_mode == "STANDARD"`:

```hcl
# BGP best path selection mode - always set
bgp_best_path_selection_mode = var.bgp_best_path_selection_mode

# BGP MED and inter-region cost - only valid with STANDARD mode
# GCP API rejects these fields when mode is LEGACY, even if set to false/null
bgp_always_compare_med = var.bgp_best_path_selection_mode == "STANDARD" ? var.bgp_always_compare_med : null
bgp_inter_region_cost  = var.bgp_best_path_selection_mode == "STANDARD" ? var.bgp_inter_region_cost : null
```

## Testing

Tested with a minimal reproducer that creates two VPCs:
1. LEGACY mode (default) - ✅ **Now succeeds** (previously failed)
2. STANDARD mode (explicit) - ✅ **Still succeeds**

Both test cases pass with this fix.

## References

- Fixes #653
- Related: #615, #616 (similar issue in v11.1.0, fixed in v11.1.1, regressed in v12.0.0)
- [GCP API Documentation](https://cloud.google.com/network-connectivity/docs/router/how-to/create-network-set-modes#api_1)
