### PR TITLE
Fix deprecation warnings in subnets and vpc modules

### DIFF
--- a/modules/subnets/outputs.tf
+++ b/modules/subnets/outputs.tf
@@ -15,6 +15,39 @@
  */
 
 output "subnets" {
-  value       = google_compute_subnetwork.subnetwork
+value = {
+    for k, v in google_compute_subnetwork.subnetwork : k => {
+      allow_subnet_cidr_routes_overlap  = v.allow_subnet_cidr_routes_overlap
+      creation_timestamp                = v.creation_timestamp
+      deletion_policy                   = v.deletion_policy
+      description                       = v.description
+      external_ipv6_prefix              = v.external_ipv6_prefix
+      gateway_address                   = v.gateway_address
+      id                                = v.id
+      internal_ipv6_prefix              = v.internal_ipv6_prefix
+      ip_cidr_range                     = v.ip_cidr_range
+      ip_collection                     = v.ip_collection
+      ipv6_access_type                  = v.ipv6_access_type
+      ipv6_cidr_range                   = v.ipv6_cidr_range
+      ipv6_gce_endpoint                 = v.ipv6_gce_endpoint
+      log_config                        = v.log_config
+      name                              = v.name
+      network                           = v.network
+      private_ip_google_access          = v.private_ip_google_access
+      private_ipv6_google_access        = v.private_ipv6_google_access
+      project                           = v.project
+      purpose                           = v.purpose
+      region                            = v.region
+      reserved_internal_range           = v.reserved_internal_range
+      resolve_subnet_mask               = v.resolve_subnet_mask
+      role                              = v.role
+      secondary_ip_range                = v.secondary_ip_range
+      self_link                         = v.self_link
+      send_secondary_ip_range_if_empty  = v.send_secondary_ip_range_if_empty
+      stack_type                        = v.stack_type
+      state                             = v.state
+      subnetwork_id                     = v.subnetwork_id
+    }
+  }
   description = "The created subnet resources"
 }

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -15,7 +15,28 @@
  */
 
 output "network" {
-  value       = google_compute_network.network
+  value = {
+    auto_create_subnetworks                    = google_compute_network.network.auto_create_subnetworks
+    bgp_always_compare_med                     = google_compute_network.network.bgp_always_compare_med
+    bgp_best_path_selection_mode               = google_compute_network.network.bgp_best_path_selection_mode
+    bgp_inter_region_cost                      = google_compute_network.network.bgp_inter_region_cost
+    delete_bgp_always_compare_med              = google_compute_network.network.delete_bgp_always_compare_med
+    delete_default_routes_on_create            = google_compute_network.network.delete_default_routes_on_create
+    deletion_policy                            = google_compute_network.network.deletion_policy
+    description                                = google_compute_network.network.description
+    enable_ula_internal_ipv6                   = google_compute_network.network.enable_ula_internal_ipv6
+    gateway_ipv4                               = google_compute_network.network.gateway_ipv4
+    id                                         = google_compute_network.network.id
+    internal_ipv6_range                        = google_compute_network.network.internal_ipv6_range
+    mtu                                        = google_compute_network.network.mtu
+    name                                       = google_compute_network.network.name
+    network_firewall_policy_enforcement_order  = google_compute_network.network.network_firewall_policy_enforcement_order
+    network_id                                 = google_compute_network.network.network_id
+    network_profile                            = google_compute_network.network.network_profile
+    project                                    = google_compute_network.network.project
+    routing_mode                               = google_compute_network.network.routing_mode
+    self_link                                  = google_compute_network.network.self_link
+  }
   description = "The VPC resource being created"
 }
 


### PR DESCRIPTION
Fix for issue https://github.com/terraform-google-modules/terraform-google-network/issues/697 by filtering deprecated fields from resource outputs.