### PR TITLE
feat(private-service-access): add existing_peering_ranges to adopt live connections

### DIFF
--- a/modules/private-service-access/main.tf
+++ b/modules/private-service-access/main.tf
@@ -15,6 +15,7 @@
  */
 
 resource "google_compute_global_address" "private_ip_address" {
+  count         = length(var.existing_peering_ranges) == 0 ? 1 : 0
   name          = var.address_name
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
@@ -26,5 +27,5 @@ resource "google_compute_global_address" "private_ip_address" {
 resource "google_service_networking_connection" "private_vpc_connection" {
   network                 = var.network_id
   service                 = "servicenetworking.googleapis.com"
-  reserved_peering_ranges = [google_compute_global_address.private_ip_address.name]
+  reserved_peering_ranges = length(var.existing_peering_ranges) > 0 ? var.existing_peering_ranges : [google_compute_global_address.private_ip_address[0].name]
 }

--- a/modules/private-service-access/variables.tf
+++ b/modules/private-service-access/variables.tf
@@ -35,3 +35,9 @@ variable "prefix_length" {
   type        = number
   default     = 16
 }
+
+variable "existing_peering_ranges" {
+  description = "Names of pre-existing reserved IP ranges to use for the peering connection. When set, no new google_compute_global_address is created. Use this to adopt an existing service networking connection into Terraform state without recreating the address."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Problem

When importing an existing `google_service_networking_connection` into Terraform state, the `private-service-access` module always creates a new `google_compute_global_address` and uses it as the sole entry in `reserved_peering_ranges`. If the live connection was peered with a differently-named address (or with ranges not managed by this module), the import forces a replace of the live VPC peering connection.

## Solution

Add an optional `existing_peering_ranges` variable (default: `[]`). When set:
- `google_compute_global_address` is skipped (`count = 0`)
- `reserved_peering_ranges` uses the provided list directly

When empty, the module behaves exactly as before — fully backwards compatible.

## Usage (adopt a live connection)

```hcl
module "private_service_access" {
  source  = "terraform-google-modules/network//modules/private-service-access"

  project_id             = var.project_id
  network_id             = google_compute_network.vpc.id
  existing_peering_ranges = ["existing-range-name"]
}
```

## Test plan
- [ ] New module call with `existing_peering_ranges` set: plan shows 0 add/change/destroy on an imported connection
- [ ] Existing callers without the variable: behaviour identical to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)