### PR TITLE
fix(vpc): avoid deprecated numeric_id warning in network output

### DIFF
--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -48,7 +48,7 @@ module "vpc" {
 
 | Name | Description |
 |------|-------------|
-| network | The VPC resource being created |
+| network | Selected attributes of the VPC resource being created |
 | network\_id | The ID of the VPC being created |
 | network\_name | The name of the VPC being created |
 | network\_self\_link | The URI of the VPC being created |

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -15,8 +15,20 @@
  */
 
 output "network" {
-  value       = google_compute_network.network
-  description = "The VPC resource being created"
+  value = {
+    id                      = google_compute_network.network.id
+    name                    = google_compute_network.network.name
+    project                 = google_compute_network.network.project
+    self_link               = google_compute_network.network.self_link
+    gateway_ipv4            = google_compute_network.network.gateway_ipv4
+    routing_mode            = google_compute_network.network.routing_mode
+    auto_create_subnetworks = google_compute_network.network.auto_create_subnetworks
+    description             = google_compute_network.network.description
+    mtu                     = google_compute_network.network.mtu
+    network_id              = google_compute_network.network.network_id
+    numeric_id              = google_compute_network.network.network_id
+  }
+  description = "Selected attributes of the VPC resource being created"
 }
 
 output "network_name" {


### PR DESCRIPTION
This PR addresses #706 by removing the deprecation warning triggered by the network output in the VPC submodule.

Previously, the output returned the full google_compute_network.network resource object, which surfaces a deprecated provider attribute (numeric_id) during validation.
This change replaces that with an explicit object of selected stable attributes.

### Changes

- Updated `modules/vpc/outputs.tf`:

1. Replaced `output "network"` value from raw resource object to a selected attribute map.
2. Added `network_id` from `google_compute_network.network.network_id`.
3. Kept `numeric_id` as a compatibility alias mapped to `network_id`.
4. Updated `modules/vpc/README.md` output description for `network `to reflect the new shape.

### Why this approach

- Removes dependency on deprecated provider internals in output evaluation.
- Preserves backward compatibility for consumers that still read `network.numeric_id`.
- Keeps the PR scope small and focused on deprecation cleanup.

### Validation

- `terraform init` (in `modules/vpc`)
- `terraform validate` (in `modules/vpc`) -> Success

Closes #706